### PR TITLE
Add the ability to merge multiple morph-with-spines files into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,38 @@ write_morphology("output.h5", "neuron_01", points, structure)
 write_soma_mesh("output.h5", "neuron_01", vertices, triangles)
 ```
 
+### Merging
+
+```python
+from pathlib import Path
+from morph_spines import merge_morphologies_with_spines
+
+# Merge multiple files without renaming
+merge_morphologies_with_spines(
+    source_files=[Path("neuron_A.h5"), Path("neuron_B.h5")],
+    output_path=Path("merged.h5"),
+)
+
+# Merge with renaming (neuron keys and/or spines library names)
+src1 = Path("neuron_A.h5")
+src2 = Path("neuron_B.h5")
+merge_morphologies_with_spines(
+    source_files=[src1, src2],
+    output_path=Path("merged.h5"),
+    rename_map={
+        (src1, "morph_001"): "circuit_neuron_42",
+        (src2, "morph_001"): "circuit_neuron_43",
+    },
+)
+
+# Merge without meshes (smaller output)
+merge_morphologies_with_spines(
+    source_files=[Path("a.h5"), Path("b.h5")],
+    output_path=Path("merged_no_meshes.h5"),
+    include_meshes=False,
+)
+```
+
 
 ## Installation
 
@@ -59,6 +91,8 @@ pip install -e ".[test]"
 ## Features
 
 - Load and write neuron morphologies with spine data from/to HDF5 files
+- Merge multiple morph-with-spines files into one, with optional renaming of neuron keys and
+  spines library names
 - Access the spine table with per-spine properties (position, orientation, section placement)
 - Access spine skeletons (via NeuroM/MorphIO) and meshes (via trimesh)
 - Write spine tables, morphologies, soma meshes, spine meshes, and spine skeletons

--- a/src/morph_spines/__init__.py
+++ b/src/morph_spines/__init__.py
@@ -15,6 +15,7 @@ from morph_spines.utils.morph_spine_loader import (
     load_spine_table,
     load_spines,
 )
+from morph_spines.utils.morph_spine_merger import merge_morphologies_with_spines
 from morph_spines.utils.morph_spine_writer import (
     validate_spine_table,
     write_morphology,
@@ -34,6 +35,7 @@ __all__ = [
     "load_soma",
     "load_spine_table",
     "load_spines",
+    "merge_morphologies_with_spines",
     "validate_spine_table",
     "write_morphology",
     "write_soma_mesh",

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -65,10 +65,15 @@ def merge_morphologies_with_spines(
     """
     if not source_files:
         raise ValueError("source_files must not be empty")
+
+    # Normalize paths so str vs Path mismatches don't cause silent rename_map misses
+    source_files = [Path(p) for p in source_files]
+    output_path = Path(output_path)
+
     if output_path.exists():
         raise FileExistsError(f"Output file already exists: {output_path}")
 
-    rename_map = rename_map or {}
+    rename_map = {(Path(p), name): dest for (p, name), dest in (rename_map or {}).items()}
 
     _validate_sources(source_files, rename_map)
 

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -7,6 +7,7 @@ reflect any renamed groups.
 """
 
 import logging
+import warnings
 from pathlib import Path
 
 import h5py
@@ -102,6 +103,7 @@ def _validate_sources(
     """Validate source file format and check for destination name collisions."""
     morph_dest_names: list[str] = []
     spine_dest_names: list[str] = []
+    valid_keys: set[tuple[Path, str]] = set()
 
     for src_path in source_files:
         with h5py.File(src_path, "r") as h5:
@@ -130,13 +132,25 @@ def _validate_sources(
                         f"not found in /{GRP_SPINES}/{GRP_SKELETONS} of {src_path}"
                     )
 
-            # Collect all destination names for this file
-            morph_dest_names.extend(rename_map.get((src_path, k), k) for k in h5[GRP_MORPH].keys())
-            spine_dest_names.extend(rename_map.get((src_path, k), k) for k in skeletons_grp.keys())
+            # Collect valid keys and destination names for this file
+            for k in h5[GRP_MORPH].keys():
+                valid_keys.add((src_path, k))
+                morph_dest_names.append(rename_map.get((src_path, k), k))
+            for k in skeletons_grp.keys():
+                valid_keys.add((src_path, k))
+                spine_dest_names.append(rename_map.get((src_path, k), k))
 
     # Check uniqueness
     _check_duplicates(morph_dest_names, "morphology")
     _check_duplicates(spine_dest_names, "spines library")
+
+    # Warn about unused rename_map entries (do not match any name in the source files)
+    unused = set(rename_map.keys()) - valid_keys
+    if unused:
+        warnings.warn(
+            f"rename_map contains entries not found in source files: {sorted(unused)}",
+            stacklevel=3,
+        )
 
 
 def _check_duplicates(names: list[str], label: str) -> None:

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -1,0 +1,215 @@
+"""Merge multiple morphology-with-spines HDF5 files into a single output file.
+
+Provides a public function to merge morph-spines files with optional renaming
+of neuron keys and spines library names via a single rename map. The
+spine_morphology entry in the spines tables is updated automatically to
+reflect any renamed groups.
+"""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from morph_spines.core.h5_schema import (
+    COL_SPINE_MORPH,
+    GRP_EDGES,
+    GRP_MESHES,
+    GRP_MORPH,
+    GRP_SKELETONS,
+    GRP_SOMA,
+    GRP_SPINES,
+)
+
+
+def merge_morphologies_with_spines(
+    source_files: list[Path],
+    output_path: Path,
+    rename_map: dict[tuple[Path, str], str] | None = None,
+    include_meshes: bool = True,
+) -> None:
+    """Merge multiple morph-with-spines HDF5 files into one with optional renaming.
+
+    Copies all morphologies, spines tables, spines skeletons, and, optionally, soma and
+    spines meshes from the source files into a single output file.
+
+    Neuron keys and shared spines library names can be renamed via rename_map. When a neuron
+    is renamed, its neuron-specific spines group (name == neuron name) is automatically
+    renamed to match. Shared spines libraries (name != any neuron name in the file) can also
+    be renamed via the same map. In this case, their corresponding entries in the spines
+    table's spine_morphology entry will be updated accordingly.
+
+    This function can also be used to rename the entries of a single morphology-with-spines
+    file into the new output file (source files are never modified).
+
+    Args:
+        source_files: List of morph-with-spines HDF5 file paths to merge.
+        output_path: Path for the output HDF5 file. File must not already exist.
+        rename_map: Optional, mapping from (source_file_path, original_name) to desired
+            destination name. The original_name can be either a morphology key or a shared
+            spines library name. This allows duplicate names across source files as long as
+            they map to unique destination names. Keys not in the map will be copied keeping
+            their original name.
+        include_meshes: If True (default), copy /soma/meshes and /spines/meshes groups.
+            If False, omit them for a smaller output file.
+
+    Raises:
+        ValueError:
+            - If source_files is empty.
+            - If a source file does not comply to the morphology-with-spines file format.
+            - If destination names (morph or spines group) collide in the output.
+        FileExistsError: If output_path already exists.
+    """
+    if not source_files:
+        raise ValueError("source_files must not be empty")
+    if output_path.exists():
+        raise FileExistsError(f"Output file already exists: {output_path}")
+
+    rename_map = rename_map or {}
+
+    _validate_sources(source_files, rename_map)
+
+    # Pre-compute per-file name maps
+    file_name_maps: dict[Path, dict[str, str]] = {}
+    for (path, name), dest in rename_map.items():
+        if path not in file_name_maps:
+            file_name_maps[path] = {}
+        file_name_maps[path][name] = dest
+
+    with h5py.File(output_path, "w") as h5_out:
+        for src_path in source_files:
+            with h5py.File(src_path, "r") as h5_in:
+                _copy_source_file(h5_in, h5_out, file_name_maps.get(src_path, {}), include_meshes)
+
+
+def _validate_sources(
+    source_files: list[Path],
+    rename_map: dict[tuple[Path, str], str],
+) -> None:
+    """Validate source file format and check for destination name collisions."""
+    morph_dest_names: list[str] = []
+    spine_dest_names: list[str] = []
+
+    for src_path in source_files:
+        with h5py.File(src_path, "r") as h5:
+            if GRP_MORPH not in h5:
+                raise ValueError(f"Invalid file: No /{GRP_MORPH} group in {src_path}")
+
+            skeletons_grp = h5.get(f"{GRP_SPINES}/{GRP_SKELETONS}")
+            if skeletons_grp is None:
+                raise ValueError(
+                    f"Invalid file: No /{GRP_SPINES}/{GRP_SKELETONS} group in {src_path}"
+                )
+
+            for morph_key in h5[GRP_MORPH].keys():
+                # Spines table must exist
+                spine_morph_path = f"{GRP_EDGES}/{morph_key}/{COL_SPINE_MORPH}"
+                if spine_morph_path not in h5:
+                    raise ValueError(f"Invalid file: No /{spine_morph_path} dataset in {src_path}")
+
+                # All referenced spines groups must exist in the file
+                raw = h5[spine_morph_path][:]
+                referenced = {v.decode() if isinstance(v, bytes) else str(v) for v in raw}
+                missing = referenced - set(skeletons_grp.keys())
+                if missing:
+                    raise ValueError(
+                        f"Spines groups {missing} referenced by '{morph_key}' "
+                        f"not found in /{GRP_SPINES}/{GRP_SKELETONS} of {src_path}"
+                    )
+
+            # Collect all destination names for this file
+            morph_dest_names.extend(rename_map.get((src_path, k), k) for k in h5[GRP_MORPH].keys())
+            spine_dest_names.extend(rename_map.get((src_path, k), k) for k in skeletons_grp.keys())
+
+    # Check uniqueness
+    _check_duplicates(morph_dest_names, "morphology")
+    _check_duplicates(spine_dest_names, "spines library")
+
+
+def _check_duplicates(names: list[str], label: str) -> None:
+    """Raise ValueError if any name appears more than once."""
+    seen: set[str] = set()
+    for name in names:
+        if name in seen:
+            raise ValueError(f"Duplicate {label} destination name: '{name}'")
+        seen.add(name)
+
+
+def _copy_source_file(
+    h5_in: h5py.File,
+    h5_out: h5py.File,
+    name_map: dict[str, str],
+    include_meshes: bool,
+) -> None:
+    """Copy all groups from one source file into the output."""
+    # /morphology/{name}
+    for name in h5_in[GRP_MORPH].keys():
+        dst_grp = h5_out.require_group(GRP_MORPH)
+        h5_in.copy(h5_in[f"{GRP_MORPH}/{name}"], dst_grp, name=name_map.get(name, name))
+
+    # /edges/{name} -- spines table; spine_morphology column may need update
+    for name in h5_in[GRP_EDGES].keys():
+        _copy_spines_table(h5_in, h5_out, name, name_map.get(name, name), name_map)
+
+    # /soma/meshes/{name} (optional)
+    if include_meshes:
+        soma_mesh_path = f"{GRP_SOMA}/{GRP_MESHES}"
+        src_parent = h5_in.get(soma_mesh_path)
+        if src_parent is not None:
+            dst_grp = h5_out.require_group(soma_mesh_path)
+            for name in src_parent.keys():
+                h5_in.copy(src_parent[name], dst_grp, name=name_map.get(name, name))
+
+    # /spines/skeletons/{name}
+    skel_parent = h5_in[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+    dst_grp = h5_out.require_group(f"{GRP_SPINES}/{GRP_SKELETONS}")
+    for name in skel_parent.keys():
+        h5_in.copy(skel_parent[name], dst_grp, name=name_map.get(name, name))
+
+    # /spines/meshes/{name} (optional)
+    if include_meshes:
+        mesh_parent = h5_in.get(f"{GRP_SPINES}/{GRP_MESHES}")
+        if mesh_parent is not None:
+            dst_grp = h5_out.require_group(f"{GRP_SPINES}/{GRP_MESHES}")
+            for name in mesh_parent.keys():
+                h5_in.copy(mesh_parent[name], dst_grp, name=name_map.get(name, name))
+
+
+def _copy_spines_table(
+    h5_in: h5py.File,
+    h5_out: h5py.File,
+    src_name: str,
+    neuron_dest_name: str,
+    name_map: dict[str, str],
+) -> None:
+    """Copy one spines table and update with optional renamings.
+
+    Source spines table (/edges/{src}) is copied to output /edges/{dest}, updating
+    the spine_morphology entry with the renamed values in name_map.
+    """
+    src_grp = h5_in[f"{GRP_EDGES}/{src_name}"]
+    dst_grp = h5_out.require_group(GRP_EDGES).create_group(neuron_dest_name)
+
+    # Determine which spine_morphology values need updating
+    raw = src_grp[COL_SPINE_MORPH][:]
+    spine_morph_values = np.array(
+        [v.decode() if isinstance(v, bytes) else str(v) for v in raw], dtype=object
+    )
+    needs_update = False
+    for old_name in set(spine_morph_values):
+        new_name = name_map.get(old_name, old_name)
+        if new_name != old_name:
+            spine_morph_values[spine_morph_values == old_name] = new_name
+            needs_update = True
+
+    dt = h5py.string_dtype(encoding="utf-8")
+    for ds_name in src_grp:
+        if isinstance(src_grp[ds_name], h5py.Group):
+            # Metadata subgroup
+            h5_in.copy(src_grp[ds_name], dst_grp, name=ds_name)
+        elif ds_name == COL_SPINE_MORPH and needs_update:
+            # spine_morphology entry, only if it needs to be updated
+            dst_grp.create_dataset(COL_SPINE_MORPH, data=spine_morph_values, dtype=dt)
+        else:
+            # The rest of the spines table is copied as-is
+            h5_in.copy(src_grp[ds_name], dst_grp, name=ds_name)

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -6,10 +6,13 @@ spine_morphology entry in the spines tables is updated automatically to
 reflect any renamed groups.
 """
 
+import logging
 from pathlib import Path
 
 import h5py
 import numpy as np
+
+L = logging.getLogger(__name__)
 
 from morph_spines.core.h5_schema import (
     COL_SPINE_MORPH,
@@ -76,10 +79,15 @@ def merge_morphologies_with_spines(
             file_name_maps[path] = {}
         file_name_maps[path][name] = dest
 
+    L.info("Merging %d source file(s) into %s", len(source_files), output_path)
+
     with h5py.File(output_path, "w") as h5_out:
-        for src_path in source_files:
+        for i, src_path in enumerate(source_files, 1):
+            L.info("Processing file %d/%d: %s", i, len(source_files), src_path)
             with h5py.File(src_path, "r") as h5_in:
                 _copy_source_file(h5_in, h5_out, file_name_maps.get(src_path, {}), include_meshes)
+
+    L.info("Merge complete: %s", output_path)
 
 
 def _validate_sources(

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -217,12 +217,9 @@ def _copy_spines_table(
 
     dt = h5py.string_dtype(encoding="utf-8")
     for ds_name in src_grp:
-        if isinstance(src_grp[ds_name], h5py.Group):
-            # Metadata subgroup
-            h5_in.copy(src_grp[ds_name], dst_grp, name=ds_name)
-        elif ds_name == COL_SPINE_MORPH and needs_update:
+        if ds_name == COL_SPINE_MORPH and needs_update:
             # spine_morphology entry, only if it needs to be updated
             dst_grp.create_dataset(COL_SPINE_MORPH, data=spine_morph_values, dtype=dt)
         else:
-            # The rest of the spines table is copied as-is
+            # The rest of the spines table is copied as-is, including metadata group
             h5_in.copy(src_grp[ds_name], dst_grp, name=ds_name)

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -12,8 +12,6 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-L = logging.getLogger(__name__)
-
 from morph_spines.core.h5_schema import (
     COL_SPINE_MORPH,
     GRP_EDGES,
@@ -23,6 +21,8 @@ from morph_spines.core.h5_schema import (
     GRP_SOMA,
     GRP_SPINES,
 )
+
+L = logging.getLogger(__name__)
 
 
 def merge_morphologies_with_spines(

--- a/tests/unit/utils/test_morph_spine_merger.py
+++ b/tests/unit/utils/test_morph_spine_merger.py
@@ -1,0 +1,426 @@
+"""Unit tests for morph_spines.utils.morph_spine_merger."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from morph_spines.core.h5_schema import (
+    COL_SPINE_MORPH,
+    GRP_EDGES,
+    GRP_MESHES,
+    GRP_MORPH,
+    GRP_SKELETONS,
+    GRP_SOMA,
+    GRP_SPINES,
+)
+from morph_spines.utils.morph_spine_merger import merge_morphologies_with_spines
+from morph_spines.utils.morph_spine_writer import (
+    write_morphology,
+    write_soma_mesh,
+    write_spine_meshes,
+    write_spine_skeletons,
+    write_spine_table,
+)
+
+SAMPLE_POINTS = np.array(
+    [[0.0, 0.0, 0.0, 0.5], [1.0, 0.0, 0.0, 0.4], [2.0, 0.0, 0.0, 0.3]], dtype=np.float64
+)
+SAMPLE_STRUCTURE = np.array([[0, 2, -1]], dtype=np.int32)
+SAMPLE_VERTICES = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+SAMPLE_TRIANGLES = np.array([[0, 1, 2]], dtype=np.int32)
+SAMPLE_OFFSETS = np.array([[0, 0], [3, 1]], dtype=np.int32)
+
+
+def _make_spine_table(spine_morph_name: str, n_spines: int = 3) -> pd.DataFrame:
+    """Create a minimal valid spine table with spine_morphology referencing the given name."""
+    return pd.DataFrame(
+        {
+            "afferent_surface_x": np.zeros(n_spines),
+            "afferent_surface_y": np.zeros(n_spines),
+            "afferent_surface_z": np.zeros(n_spines),
+            "afferent_center_x": np.zeros(n_spines),
+            "afferent_center_y": np.zeros(n_spines),
+            "afferent_center_z": np.zeros(n_spines),
+            "spine_morphology": [spine_morph_name] * n_spines,
+            "spine_id": np.arange(n_spines, dtype=np.uint32),
+            "spine_length": np.ones(n_spines),
+            "spine_orientation_vector_x": np.zeros(n_spines),
+            "spine_orientation_vector_y": np.zeros(n_spines),
+            "spine_orientation_vector_z": np.ones(n_spines),
+            "spine_rotation_x": np.zeros(n_spines),
+            "spine_rotation_y": np.zeros(n_spines),
+            "spine_rotation_z": np.zeros(n_spines),
+            "spine_rotation_w": np.ones(n_spines),
+            "afferent_section_id": np.arange(1, n_spines + 1, dtype=np.uint32),
+            "afferent_segment_id": np.arange(n_spines, dtype=np.int32),
+            "afferent_segment_offset": np.zeros(n_spines),
+            "afferent_section_pos": np.zeros(n_spines),
+        }
+    )
+
+
+def _create_source_file(
+    filepath: Path,
+    neuron_name: str,
+    *,
+    spine_group_name: str | None = None,
+    include_meshes: bool = True,
+    n_spines: int = 3,
+) -> None:
+    """Create a complete morph-with-spines source file for testing."""
+    spine_grp = spine_group_name if spine_group_name is not None else neuron_name
+
+    write_morphology(str(filepath), neuron_name, SAMPLE_POINTS, SAMPLE_STRUCTURE)
+    write_spine_table(str(filepath), neuron_name, _make_spine_table(spine_grp, n_spines))
+    write_spine_skeletons(str(filepath), spine_grp, SAMPLE_POINTS, SAMPLE_STRUCTURE)
+
+    if include_meshes:
+        write_soma_mesh(str(filepath), neuron_name, SAMPLE_VERTICES, SAMPLE_TRIANGLES)
+        write_spine_meshes(
+            str(filepath), spine_grp, SAMPLE_VERTICES, SAMPLE_TRIANGLES, SAMPLE_OFFSETS
+        )
+
+
+class TestValidation:
+    def test_empty_source_files(self, tmp_path):
+        with pytest.raises(ValueError, match="source_files must not be empty"):
+            merge_morphologies_with_spines([], tmp_path / "out.h5")
+
+    def test_output_already_exists(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+        output.touch()
+
+        with pytest.raises(FileExistsError):
+            merge_morphologies_with_spines([src], output)
+
+    def test_missing_morphology_group(self, tmp_path):
+        src = tmp_path / "bad.h5"
+        with h5py.File(src, "w") as h5:
+            h5.create_group("other")
+
+        with pytest.raises(ValueError, match="Invalid file: No /morphology group"):
+            merge_morphologies_with_spines([src], tmp_path / "out.h5")
+
+    def test_missing_spines_table(self, tmp_path):
+        src = tmp_path / "src.h5"
+        write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        # Add /spines/skeletons so validation gets past that check
+        write_spine_skeletons(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+
+        with pytest.raises(ValueError, match="Invalid file: No /edges/neuron_A/spine_morphology"):
+            merge_morphologies_with_spines([src], tmp_path / "out.h5")
+
+    def test_duplicate_destination_names(self, tmp_path):
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A")
+        _create_source_file(src2, "neuron_B")
+
+        rename = {(src1, "neuron_A"): "same", (src2, "neuron_B"): "same"}
+        with pytest.raises(ValueError, match="Duplicate morphology destination name"):
+            merge_morphologies_with_spines([src1, src2], tmp_path / "out.h5", rename_map=rename)
+
+    def test_duplicate_names_without_rename(self, tmp_path):
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A")
+        _create_source_file(src2, "neuron_A")
+
+        with pytest.raises(ValueError, match="Duplicate morphology destination name"):
+            merge_morphologies_with_spines([src1, src2], tmp_path / "out.h5")
+
+
+class TestMergeNoRename:
+    def test_single_file(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output)
+
+        with h5py.File(output, "r") as h5:
+            assert "neuron_A" in h5[GRP_MORPH]
+            assert "neuron_A" in h5[GRP_EDGES]
+            assert "neuron_A" in h5[f"{GRP_SOMA}/{GRP_MESHES}"]
+            assert "neuron_A" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+            assert "neuron_A" in h5[f"{GRP_SPINES}/{GRP_MESHES}"]
+
+    def test_multiple_files(self, tmp_path):
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A", n_spines=5)
+        _create_source_file(src2, "neuron_B", n_spines=7)
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src1, src2], output)
+
+        with h5py.File(output, "r") as h5:
+            assert set(h5[GRP_MORPH].keys()) == {"neuron_A", "neuron_B"}
+            # Data integrity: total spines preserved
+            total = sum(len(h5[f"{GRP_EDGES}/{k}/spine_id"][:]) for k in h5[GRP_EDGES].keys())
+            assert total == 12
+
+    def test_preserves_data_byte_for_byte(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output)
+
+        with h5py.File(output, "r") as h5:
+            # Morphology skeleton
+            np.testing.assert_array_equal(h5[f"{GRP_MORPH}/neuron_A/points"][:], SAMPLE_POINTS)
+            np.testing.assert_array_equal(
+                h5[f"{GRP_MORPH}/neuron_A/structure"][:], SAMPLE_STRUCTURE
+            )
+            # Spine skeletons
+            np.testing.assert_array_equal(
+                h5[f"{GRP_SPINES}/{GRP_SKELETONS}/neuron_A/points"][:], SAMPLE_POINTS
+            )
+            # Soma mesh
+            np.testing.assert_array_equal(
+                h5[f"{GRP_SOMA}/{GRP_MESHES}/neuron_A/vertices"][:], SAMPLE_VERTICES
+            )
+            # Spine mesh
+            np.testing.assert_array_equal(
+                h5[f"{GRP_SPINES}/{GRP_MESHES}/neuron_A/vertices"][:], SAMPLE_VERTICES
+            )
+
+    def test_multi_neuron_single_file(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A", n_spines=3)
+        write_morphology(str(src), "neuron_B", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        write_spine_table(str(src), "neuron_B", _make_spine_table("neuron_B", 4))
+        write_spine_skeletons(str(src), "neuron_B", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, include_meshes=False)
+
+        with h5py.File(output, "r") as h5:
+            assert set(h5[GRP_MORPH].keys()) == {"neuron_A", "neuron_B"}
+
+
+class TestMergeWithRename:
+    def test_renames_all_groups(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "old")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, rename_map={(src, "old"): "new"})
+
+        with h5py.File(output, "r") as h5:
+            for grp in [
+                GRP_MORPH,
+                GRP_EDGES,
+                f"{GRP_SOMA}/{GRP_MESHES}",
+                f"{GRP_SPINES}/{GRP_SKELETONS}",
+                f"{GRP_SPINES}/{GRP_MESHES}",
+            ]:
+                assert "new" in h5[grp]
+                assert "old" not in h5[grp]
+
+    def test_updates_spine_morphology_column(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "old", n_spines=4)
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, rename_map={(src, "old"): "new"})
+
+        with h5py.File(output, "r") as h5:
+            values = h5[f"{GRP_EDGES}/new/{COL_SPINE_MORPH}"][:]
+            decoded = {v.decode() if isinstance(v, bytes) else str(v) for v in values}
+            assert decoded == {"new"}
+
+    def test_shared_spine_group_not_renamed(self, tmp_path):
+        """Shared spine group keeps its name when only the neuron is renamed."""
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A", spine_group_name="shared_lib")
+        output = tmp_path / "out.h5"
+
+        # Two rename entries for the same file: neuron renamed, lib keeps its name
+        merge_morphologies_with_spines(
+            [src],
+            output,
+            rename_map={(src, "neuron_A"): "renamed", (src, "shared_lib"): "shared_lib"},
+        )
+
+        with h5py.File(output, "r") as h5:
+            assert "renamed" in h5[GRP_MORPH]
+            assert "shared_lib" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+            assert "renamed" not in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+
+    def test_shared_spine_group_overlap_raises(self, tmp_path):
+        """Two files with the same shared spine group name without rename -> rejected."""
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A", spine_group_name="shared")
+        _create_source_file(src2, "neuron_B", spine_group_name="shared")
+
+        with pytest.raises(ValueError, match="Duplicate spines library destination name"):
+            merge_morphologies_with_spines([src1, src2], tmp_path / "out.h5")
+
+    def test_shared_spine_group_overlap_with_rename(self, tmp_path):
+        """Two files with same shared spine group, renamed to different names -> OK."""
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A", spine_group_name="shared")
+        _create_source_file(src2, "neuron_B", spine_group_name="shared")
+        output = tmp_path / "out.h5"
+
+        rename = {(src1, "shared"): "shared_from_1", (src2, "shared"): "shared_from_2"}
+        merge_morphologies_with_spines([src1, src2], output, rename_map=rename)
+
+        with h5py.File(output, "r") as h5:
+            assert "shared_from_1" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+            assert "shared_from_2" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+            # spine_morphology columns updated
+            vals_a = h5[f"{GRP_EDGES}/neuron_A/{COL_SPINE_MORPH}"][:]
+            assert all(
+                (v.decode() if isinstance(v, bytes) else str(v)) == "shared_from_1" for v in vals_a
+            )
+            vals_b = h5[f"{GRP_EDGES}/neuron_B/{COL_SPINE_MORPH}"][:]
+            assert all(
+                (v.decode() if isinstance(v, bytes) else str(v)) == "shared_from_2" for v in vals_b
+            )
+
+    def test_rename_only_specified_keys(self, tmp_path):
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A")
+        _create_source_file(src2, "neuron_B")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines(
+            [src1, src2], output, rename_map={(src1, "neuron_A"): "renamed_A"}
+        )
+
+        with h5py.File(output, "r") as h5:
+            assert set(h5[GRP_MORPH].keys()) == {"renamed_A", "neuron_B"}
+
+    def test_duplicate_names_across_files_with_rename(self, tmp_path):
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A")
+        _create_source_file(src2, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        rename = {(src1, "neuron_A"): "from_file1", (src2, "neuron_A"): "from_file2"}
+        merge_morphologies_with_spines([src1, src2], output, rename_map=rename)
+
+        with h5py.File(output, "r") as h5:
+            assert set(h5[GRP_MORPH].keys()) == {"from_file1", "from_file2"}
+
+    def test_longer_name_not_truncated(self, tmp_path):
+        """Regression: renaming to a longer string must not truncate."""
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "a", n_spines=3)
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines(
+            [src], output, rename_map={(src, "a"): "very_long_destination_name"}
+        )
+
+        with h5py.File(output, "r") as h5:
+            values = h5[f"{GRP_EDGES}/very_long_destination_name/{COL_SPINE_MORPH}"][:]
+            decoded = [v.decode() if isinstance(v, bytes) else str(v) for v in values]
+            assert all(v == "very_long_destination_name" for v in decoded)
+
+
+class TestIncludeMeshes:
+    def test_meshes_included_by_default(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output)
+
+        with h5py.File(output, "r") as h5:
+            assert f"{GRP_SOMA}/{GRP_MESHES}/neuron_A" in h5
+            assert f"{GRP_SPINES}/{GRP_MESHES}/neuron_A" in h5
+
+    def test_meshes_excluded(self, tmp_path):
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, include_meshes=False)
+
+        with h5py.File(output, "r") as h5:
+            assert f"{GRP_SOMA}/{GRP_MESHES}" not in h5
+            assert f"{GRP_SPINES}/{GRP_MESHES}" not in h5
+            # Skeletons always copied
+            assert f"{GRP_SPINES}/{GRP_SKELETONS}/neuron_A" in h5
+
+    def test_missing_soma_meshes_in_source(self, tmp_path):
+        """Source without soma meshes merges fine with include_meshes=True."""
+        src = tmp_path / "src.h5"
+        write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        write_spine_table(str(src), "neuron_A", _make_spine_table("neuron_A", 2))
+        write_spine_skeletons(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, include_meshes=True)
+
+        with h5py.File(output, "r") as h5:
+            assert "neuron_A" in h5[GRP_MORPH]
+            assert f"{GRP_SOMA}/{GRP_MESHES}" not in h5
+
+
+class TestEdgeCases:
+    def test_missing_spine_skeletons_group_raises(self, tmp_path):
+        """Source with spines table but no /spines/skeletons is rejected."""
+        src = tmp_path / "src.h5"
+        write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        write_spine_table(str(src), "neuron_A", _make_spine_table("neuron_A", 2))
+
+        with pytest.raises(ValueError, match="Invalid file: No /spines/skeletons group"):
+            merge_morphologies_with_spines([src], tmp_path / "out.h5", include_meshes=False)
+
+    def test_missing_referenced_spine_group_raises(self, tmp_path):
+        """Source file referencing a spine group not in /spines/skeletons is rejected."""
+        src = tmp_path / "src.h5"
+        write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        write_spine_table(str(src), "neuron_A", _make_spine_table("missing_group", 2))
+        write_spine_skeletons(str(src), "other_group", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+
+        with pytest.raises(ValueError, match="not found in /spines/skeletons"):
+            merge_morphologies_with_spines([src], tmp_path / "out.h5")
+
+    def test_referential_integrity_after_rename(self, tmp_path):
+        """All spine_morphology values reference existing spines groups."""
+        src1 = tmp_path / "src1.h5"
+        src2 = tmp_path / "src2.h5"
+        _create_source_file(src1, "neuron_A")
+        _create_source_file(src2, "neuron_B")
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines(
+            [src1, src2], output, rename_map={(src1, "neuron_A"): "renamed_A"}
+        )
+
+        with h5py.File(output, "r") as h5:
+            skeleton_keys = set(h5[f"{GRP_SPINES}/{GRP_SKELETONS}"].keys())
+            for neuron_key in h5[GRP_EDGES].keys():
+                values = h5[f"{GRP_EDGES}/{neuron_key}/{COL_SPINE_MORPH}"][:]
+                decoded = {v.decode() if isinstance(v, bytes) else str(v) for v in values}
+                assert decoded.issubset(skeleton_keys)
+
+    def test_shared_spine_group_in_same_file_copied_once(self, tmp_path):
+        """Two morphologies in the same file sharing a spine group -> copied once."""
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A", spine_group_name="shared")
+        # Add second neuron referencing the same shared group
+        write_morphology(str(src), "neuron_B", SAMPLE_POINTS, SAMPLE_STRUCTURE)
+        write_spine_table(str(src), "neuron_B", _make_spine_table("shared", 2))
+        output = tmp_path / "out.h5"
+
+        merge_morphologies_with_spines([src], output, include_meshes=False)
+
+        with h5py.File(output, "r") as h5:
+            assert set(h5[GRP_MORPH].keys()) == {"neuron_A", "neuron_B"}
+            assert "shared" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]

--- a/tests/unit/utils/test_morph_spine_merger.py
+++ b/tests/unit/utils/test_morph_spine_merger.py
@@ -1,5 +1,6 @@
 """Unit tests for morph_spines.utils.morph_spine_merger."""
 
+import warnings
 from pathlib import Path
 
 import h5py
@@ -424,3 +425,32 @@ class TestEdgeCases:
         with h5py.File(output, "r") as h5:
             assert set(h5[GRP_MORPH].keys()) == {"neuron_A", "neuron_B"}
             assert "shared" in h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+
+
+class TestUnusedRenameMapWarning:
+    def test_unused_entry_emits_warning(self, tmp_path):
+        """A rename_map key that doesn't match any source name emits a warning."""
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            merge_morphologies_with_spines(
+                [src], output, rename_map={(src, "nonexistent"): "whatever"}
+            )
+
+        assert len(caught) == 1
+        assert "not found in source files" in str(caught[0].message)
+
+    def test_no_warning_when_all_entries_used(self, tmp_path):
+        """No warning when every rename_map key matches a source name."""
+        src = tmp_path / "src.h5"
+        _create_source_file(src, "neuron_A")
+        output = tmp_path / "out.h5"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            merge_morphologies_with_spines([src], output, rename_map={(src, "neuron_A"): "renamed"})
+
+        assert len(caught) == 0


### PR DESCRIPTION
Fixes #37 

# Description
Add `merge_morphologies_with_spines` API function to merge multiple morphology-with-spines HDF5 files into a single output file, with optional renaming of neuron keys and spines library names.

## Features
- Merge any number of morph-with-spines files into one output
- Rename neuron keys and/or spines library names via a `rename_map` keyed by `(source_file_path, original_name)`
- `spine_morphology` entry in the spines tables is updated on the fly during copy
- Supports duplicate input morph/spine names across source files as long as they're renamed to unique destinations
- `include_meshes` parameter to optionally exclude soma and spine mesh data in the output file
- Validation: fail-fast, before any output is written:
  - Source files must be valid morph-with-spines format
  - All `spine_morphology` values must reference existing groups in input file's /spines/skeletons group
  - Destination names must be unique (both morphology keys and spines library names, checked independently)

## Testing
- Input validation (empty files, missing groups, duplicates)
- Merge without renaming (single file, multiple files, multi-neuron files, data preservation)
- Merge with renaming (neuron rename, shared library rename, overlap detection, longer names)
- include_meshes test
- Edge cases (missing soma meshes, missing referenced groups, spines shared library)

## Documentation
- Updated README with examples