### PR TITLE
Add morph-with-spines file validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ write_morphology("output.h5", "neuron_01", points, structure)
 write_soma_mesh("output.h5", "neuron_01", vertices, triangles)
 ```
 
+### Validation
+
+```python
+from morph_spines import validate_morph_with_spines_file
+
+# Check file structure only (groups, datasets, metadata)
+result = validate_morph_with_spines_file("neuron.h5")
+
+# Also check data integrity (shapes, dtypes, value ranges, cross-references)
+result = validate_morph_with_spines_file("neuron.h5", check_data_integrity=True)
+
+print(result)          # Human-readable summary
+assert result.is_valid # Use programmatically
+```
+
 
 ## Installation
 
@@ -63,6 +78,7 @@ pip install -e ".[test]"
 - Access spine skeletons (via NeuroM/MorphIO) and meshes (via trimesh)
 - Write spine tables, morphologies, soma meshes, spine meshes, and spine skeletons
 - Validate spine tables against the format specification before writing
+- Validate entire morph-with-spines files (structure and optionally data integrity)
 - Head/neck triangle classification with filtering (`include_head`, `include_neck`)
 - Support for branched spines with multiple heads
 - Spine type classification (thin, mushroom, stubby, filopodium, branched, etc.)

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -169,8 +169,11 @@ spine meshes will be stored under `/spines/meshes/01234`.
 The spine meshes are represented with three datasets: `/offsets`, `/triangles` and `/vertices`.
 These three datasets are the only ones stored compressed in the HDF5 file.
 
-The `/triangles` and `/vertices` datasets represent points and triangles in the 3D space in the
-same way as the `/soma/meshes` are described.
+The `/vertices` dataset contains all vertex positions (x, y, z) for all spines concatenated into a
+single flat array. Similarly, the `/triangles` dataset contains all triangle definitions for all
+spines concatenated into a single flat array. Within each spine's triangle slice, vertex indices
+are local (0-based relative to that spine's vertex slice, not global into the full `/vertices`
+array).
 
 The `/offsets` dataset is a list of pairs where each pair points at the first `vertex` and 
 `triangle` of each spine respectively. For easiness, if there are `NS` spines, there will be `NS+1`
@@ -183,6 +186,7 @@ Therefore, to get the mesh for the spine with ID `IDS`, we can do the following:
 ```python
 spine_vertices = neuron_vertices[neuron_offsets[IDS]:neuron_offsets[IDS+1]]
 spine_triangles = neuron_triangles[neuron_offsets[IDS]:neuron_offsets[IDS+1]]
+# spine_triangles contains indices into spine_vertices (not neuron_vertices)
 ```
 
 #### Head/neck triangle classification (optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = [
     "-vv",
     "-ra",

--- a/src/morph_spines/__init__.py
+++ b/src/morph_spines/__init__.py
@@ -15,6 +15,10 @@ from morph_spines.utils.morph_spine_loader import (
     load_spine_table,
     load_spines,
 )
+from morph_spines.utils.morph_spine_validator import (
+    ValidationResult,
+    validate_morph_with_spines_file,
+)
 from morph_spines.utils.morph_spine_writer import (
     validate_spine_table,
     write_morphology,
@@ -29,11 +33,13 @@ __all__ = [
     "SpineType",
     "Spines",
     "MorphologyWithSpines",
+    "ValidationResult",
     "load_morphology",
     "load_morphology_with_spines",
     "load_soma",
     "load_spine_table",
     "load_spines",
+    "validate_morph_with_spines_file",
     "validate_spine_table",
     "write_morphology",
     "write_soma_mesh",

--- a/src/morph_spines/utils/morph_spine_merger.py
+++ b/src/morph_spines/utils/morph_spine_merger.py
@@ -101,36 +101,24 @@ def _validate_sources(
     rename_map: dict[tuple[Path, str], str],
 ) -> None:
     """Validate source file format and check for destination name collisions."""
+    from morph_spines.utils.morph_spine_validator import (
+        validate_morph_with_spines_file,
+    )
+
     morph_dest_names: list[str] = []
     spine_dest_names: list[str] = []
     valid_keys: set[tuple[Path, str]] = set()
 
     for src_path in source_files:
+        # Use the file validator for structural checks
+        result = validate_morph_with_spines_file(src_path)
+        if not result.is_valid:
+            raise ValueError(
+                f"Invalid file {src_path}:\n" + "\n".join(f"  - {e}" for e in result.errors)
+            )
+
         with h5py.File(src_path, "r") as h5:
-            if GRP_MORPH not in h5:
-                raise ValueError(f"Invalid file: No /{GRP_MORPH} group in {src_path}")
-
-            skeletons_grp = h5.get(f"{GRP_SPINES}/{GRP_SKELETONS}")
-            if skeletons_grp is None:
-                raise ValueError(
-                    f"Invalid file: No /{GRP_SPINES}/{GRP_SKELETONS} group in {src_path}"
-                )
-
-            for morph_key in h5[GRP_MORPH].keys():
-                # Spines table must exist
-                spine_morph_path = f"{GRP_EDGES}/{morph_key}/{COL_SPINE_MORPH}"
-                if spine_morph_path not in h5:
-                    raise ValueError(f"Invalid file: No /{spine_morph_path} dataset in {src_path}")
-
-                # All referenced spines groups must exist in the file
-                raw = h5[spine_morph_path][:]
-                referenced = {v.decode() if isinstance(v, bytes) else str(v) for v in raw}
-                missing = referenced - set(skeletons_grp.keys())
-                if missing:
-                    raise ValueError(
-                        f"Spines groups {missing} referenced by '{morph_key}' "
-                        f"not found in /{GRP_SPINES}/{GRP_SKELETONS} of {src_path}"
-                    )
+            skeletons_grp = h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
 
             # Collect valid keys and destination names for this file
             for k in h5[GRP_MORPH].keys():
@@ -144,7 +132,7 @@ def _validate_sources(
     _check_duplicates(morph_dest_names, "morphology")
     _check_duplicates(spine_dest_names, "spines library")
 
-    # Warn about unused rename_map entries (do not match any name in the source files)
+    # Warn about unused rename_map entries
     unused = set(rename_map.keys()) - valid_keys
     if unused:
         warnings.warn(

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -9,7 +9,8 @@ Structure checks (always performed):
     - /morphology/{name}: is a group with 'points' and 'structure' datasets.
     - /edges/{name}: is a group with 'metadata' subgroup containing 'version'
       attribute; 'version' is (1, 0); all mandatory column datasets present
-      (spines table).
+      (spines table); spine_morphology references existing /spines/skeletons
+      groups.
     - /spines/skeletons/{name}: is a group with 'points' and 'structure' datasets.
     - /spines/meshes/{name} (optional): if present, it contains 'vertices', 'triangles'
       and 'offsets' datasets.
@@ -30,7 +31,6 @@ Data integrity checks (when check_data_integrity=True):
     - /edges spine_type values are valid SpineType enum values (if present).
     - /edges spine_volume values > 0 (if present).
     - /edges spine_neck_diameter values > 0 (if present).
-    - /edges spine_morphology references existing /spines/skeletons groups.
     - /spines/skeletons points: shape (N, 4), float32 dtype, no NaN/Inf, non-empty.
     - /spines/skeletons structure: shape (M, 3), non-empty.
     - /spines/meshes vertices: shape (N, 3), no NaN/Inf.
@@ -376,6 +376,23 @@ def _validate_edges_group(edges_grp: h5py.Group, check_data_integrity: bool) -> 
                 f"/edges/{name}: unknown column datasets (not in spec): {sorted(unknown_cols)}"
             )
 
+        # Check spine_morphology references existing /spines/skeletons groups
+        if "spine_morphology" in dataset_keys:
+            spine_morph_dset = item["spine_morphology"]
+            if isinstance(spine_morph_dset, h5py.Dataset):
+                h5_file = item.file
+                skeletons_path = f"{GRP_SPINES}/{GRP_SKELETONS}"
+                if skeletons_path in h5_file:
+                    skeleton_names = set(h5_file[skeletons_path].keys())
+                    values = set(spine_morph_dset[:].astype(str))
+                    missing = values - skeleton_names
+                    if missing:
+                        result.add_error(
+                            f"/edges/{name}/spine_morphology: "
+                            f"references groups not in "
+                            f"/{skeletons_path}: {sorted(missing)}"
+                        )
+
         if check_data_integrity:
             _validate_edges_data_integrity(item, name, result)
 
@@ -463,20 +480,6 @@ def _validate_edges_data_integrity(
         invalid_types = actual_types - valid_types
         if invalid_types:
             result.add_error(f"/edges/{name}/spine_type: unknown values: {sorted(invalid_types)}")
-
-    # Validate spine_morphology references existing /spines/skeletons subgroups
-    if "spine_morphology" in dataset_keys:
-        spine_morph_values = set(spine_table_grp["spine_morphology"][:].astype(str))
-        h5_file = spine_table_grp.file
-        skeletons_path = f"{GRP_SPINES}/{GRP_SKELETONS}"
-        if skeletons_path in h5_file:
-            skeleton_names = set(h5_file[skeletons_path].keys())
-            missing = spine_morph_values - skeleton_names
-            if missing:
-                result.add_error(
-                    f"/edges/{name}/spine_morphology: references groups not in "
-                    f"/{skeletons_path}: {sorted(missing)}"
-                )
 
 
 def _validate_spines_group(spines_grp: h5py.Group, check_data_integrity: bool) -> ValidationResult:

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -26,6 +26,10 @@ Data integrity checks (when check_data_integrity=True):
     - /edges afferent_section_pos values in [0, 1].
     - /edges spine_length values > 0.
     - /edges afferent_segment_offset values >= 0.
+    - /edges afferent_segment_id values >= 0.
+    - /edges spine_type values are valid SpineType enum values (if present).
+    - /edges spine_volume values > 0 (if present).
+    - /edges spine_neck_diameter values > 0 (if present).
     - /edges spine_morphology references existing /spines/skeletons groups.
     - /spines/skeletons points: shape (N, 4), float32 dtype, no NaN/Inf, non-empty.
     - /spines/skeletons structure: shape (M, 3), non-empty.
@@ -40,6 +44,8 @@ Data integrity checks (when check_data_integrity=True):
     - Cross-group: spine_morphology values reference existing /spines/meshes groups.
     - Cross-group: spine_id values are valid indices into skeleton root sections
       and mesh offsets.
+    - Cross-group: afferent_section_id values are valid section indices in
+      /morphology/{name}/structure.
 """
 
 from __future__ import annotations
@@ -423,6 +429,37 @@ def _validate_edges_data_integrity(
         if n_negative > 0:
             result.add_error(f"/edges/{name}/afferent_segment_offset: {n_negative} negative values")
 
+    # Validate afferent_segment_id >= 0
+    if "afferent_segment_id" in dataset_keys:
+        data = spine_table_grp["afferent_segment_id"][:]
+        n_negative = int(np.sum(data < 0))
+        if n_negative > 0:
+            result.add_error(f"/edges/{name}/afferent_segment_id: {n_negative} negative values")
+
+    # Validate spine_type contains only known values (optional column)
+    if "spine_type" in dataset_keys:
+        from morph_spines.core.spine_type import SpineType
+
+        valid_types = {t.value for t in SpineType}
+        actual_types = set(spine_table_grp["spine_type"][:].astype(str))
+        invalid_types = actual_types - valid_types
+        if invalid_types:
+            result.add_error(f"/edges/{name}/spine_type: unknown values: {sorted(invalid_types)}")
+
+    # Validate spine_volume > 0 (optional column)
+    if "spine_volume" in dataset_keys:
+        data = spine_table_grp["spine_volume"][:]
+        n_invalid = int(np.sum(data <= 0))
+        if n_invalid > 0:
+            result.add_error(f"/edges/{name}/spine_volume: {n_invalid} values <= 0")
+
+    # Validate spine_neck_diameter > 0 (optional column)
+    if "spine_neck_diameter" in dataset_keys:
+        data = spine_table_grp["spine_neck_diameter"][:]
+        n_invalid = int(np.sum(data <= 0))
+        if n_invalid > 0:
+            result.add_error(f"/edges/{name}/spine_neck_diameter: {n_invalid} values <= 0")
+
     # Validate spine_morphology references existing /spines/skeletons subgroups
     if "spine_morphology" in dataset_keys:
         spine_morph_values = set(spine_table_grp["spine_morphology"][:].astype(str))
@@ -681,6 +718,8 @@ def _validate_cross_group_integrity(h5: h5py.File) -> ValidationResult:
       (if meshes are present).
     - spine_id values in /edges are valid indices into the corresponding
       /spines/skeletons (root section count) and /spines/meshes (offset count).
+    - afferent_section_id values in /edges are valid section indices in
+      /morphology/{name}/structure.
     """
     result = ValidationResult()
 
@@ -777,5 +816,34 @@ def _validate_cross_group_integrity(h5: h5py.File) -> ValidationResult:
                                 f"spine_morphology='{spine_morph}' exceeds mesh "
                                 f"offset count ({n_mesh_spines})"
                             )
+
+    # Check afferent_section_id references valid sections in /morphology
+    for edge_name in edges_names:
+        edge_grp = h5[GRP_EDGES][edge_name]
+        if not isinstance(edge_grp, h5py.Group):
+            continue
+        if "afferent_section_id" not in edge_grp:
+            continue
+
+        morph_path = f"{GRP_MORPH}/{edge_name}"
+        if morph_path not in h5:
+            continue  # already reported as orphan edge
+
+        morph_grp = h5[morph_path]
+        if "structure" not in morph_grp:
+            continue
+
+        structure = morph_grp["structure"]
+        if not isinstance(structure, h5py.Dataset) or structure.ndim != 2:
+            continue
+
+        n_sections = structure.shape[0]
+        section_ids = edge_grp["afferent_section_id"][:]
+        max_section_id = int(np.max(section_ids))
+        if max_section_id >= n_sections:
+            result.add_error(
+                f"/edges/{edge_name}: afferent_section_id={max_section_id} "
+                f"exceeds morphology section count ({n_sections})"
+            )
 
     return result

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -75,6 +75,39 @@ from morph_spines.core.h5_schema import (
 )
 
 
+def check_column_values(col_name: str, data) -> list[str]:
+    """Check numeric column values for known constraints.
+
+    Args:
+        col_name: Name of the spine table column.
+        data: Array-like of values (numpy array or pandas Series).
+
+    Returns:
+        A list of error message strings. Empty if all values are valid.
+    """
+    arr = np.asarray(data)
+    errors: list[str] = []
+
+    if col_name == "afferent_section_pos":
+        n = int(np.sum((arr < 0) | (arr > 1)))
+        if n > 0:
+            errors.append(f"{col_name}: {n} values not in [0, 1]")
+    elif col_name == "spine_length":
+        n = int(np.sum(arr <= 0))
+        if n > 0:
+            errors.append(f"{col_name}: {n} values not > 0")
+    elif col_name in ("afferent_segment_offset", "afferent_segment_id"):
+        n = int(np.sum(arr < 0))
+        if n > 0:
+            errors.append(f"{col_name}: {n} values not >= 0")
+    elif col_name in ("spine_volume", "spine_neck_diameter"):
+        n = int(np.sum(arr <= 0))
+        if n > 0:
+            errors.append(f"{col_name}: {n} values not > 0")
+
+    return errors
+
+
 @dataclass
 class ValidationResult:
     """Container for validation results.
@@ -406,35 +439,20 @@ def _validate_edges_data_integrity(
                     f"/edges/{name}/{col_name}: expected integer type, got dtype '{item.dtype}'"
                 )
 
-    # Validate afferent_section_pos is in [0, 1]
-    if "afferent_section_pos" in dataset_keys:
-        data = spine_table_grp["afferent_section_pos"][:]
-        out_of_range = int(np.sum((data < 0) | (data > 1)))
-        if out_of_range > 0:
-            result.add_error(
-                f"/edges/{name}/afferent_section_pos: {out_of_range} values outside [0, 1]"
-            )
-
-    # Validate spine_length > 0
-    if "spine_length" in dataset_keys:
-        data = spine_table_grp["spine_length"][:]
-        n_invalid = int(np.sum(data <= 0))
-        if n_invalid > 0:
-            result.add_error(f"/edges/{name}/spine_length: {n_invalid} values <= 0")
-
-    # Validate afferent_segment_offset >= 0
-    if "afferent_segment_offset" in dataset_keys:
-        data = spine_table_grp["afferent_segment_offset"][:]
-        n_negative = int(np.sum(data < 0))
-        if n_negative > 0:
-            result.add_error(f"/edges/{name}/afferent_segment_offset: {n_negative} negative values")
-
-    # Validate afferent_segment_id >= 0
-    if "afferent_segment_id" in dataset_keys:
-        data = spine_table_grp["afferent_segment_id"][:]
-        n_negative = int(np.sum(data < 0))
-        if n_negative > 0:
-            result.add_error(f"/edges/{name}/afferent_segment_id: {n_negative} negative values")
+    # Validate column value ranges
+    _CHECKED_COLUMNS = (
+        "afferent_section_pos",
+        "spine_length",
+        "afferent_segment_offset",
+        "afferent_segment_id",
+        "spine_volume",
+        "spine_neck_diameter",
+    )
+    for col_name in _CHECKED_COLUMNS:
+        if col_name in dataset_keys:
+            data = spine_table_grp[col_name][:]
+            for err in check_column_values(col_name, data):
+                result.add_error(f"/edges/{name}/{err}")
 
     # Validate spine_type contains only known values (optional column)
     if "spine_type" in dataset_keys:
@@ -445,20 +463,6 @@ def _validate_edges_data_integrity(
         invalid_types = actual_types - valid_types
         if invalid_types:
             result.add_error(f"/edges/{name}/spine_type: unknown values: {sorted(invalid_types)}")
-
-    # Validate spine_volume > 0 (optional column)
-    if "spine_volume" in dataset_keys:
-        data = spine_table_grp["spine_volume"][:]
-        n_invalid = int(np.sum(data <= 0))
-        if n_invalid > 0:
-            result.add_error(f"/edges/{name}/spine_volume: {n_invalid} values <= 0")
-
-    # Validate spine_neck_diameter > 0 (optional column)
-    if "spine_neck_diameter" in dataset_keys:
-        data = spine_table_grp["spine_neck_diameter"][:]
-        n_invalid = int(np.sum(data <= 0))
-        if n_invalid > 0:
-            result.add_error(f"/edges/{name}/spine_neck_diameter: {n_invalid} values <= 0")
 
     # Validate spine_morphology references existing /spines/skeletons subgroups
     if "spine_morphology" in dataset_keys:

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -529,7 +529,9 @@ def _validate_spines_meshes(meshes_grp: h5py.Group, check_data_integrity: bool) 
 
 
 def _validate_mesh_datasets(
-    grp: h5py.Group, path: str, result: ValidationResult,
+    grp: h5py.Group,
+    path: str,
+    result: ValidationResult,
     check_global_indices: bool = True,
 ) -> None:
     """Validate vertices and triangles datasets within a mesh group.
@@ -552,10 +554,7 @@ def _validate_mesh_datasets(
         vertices = grp[GRP_VERTICES]
         if isinstance(vertices, h5py.Dataset):
             if vertices.ndim != 2 or vertices.shape[1] != 3:
-                result.add_error(
-                    f"{path}/vertices: expected shape (N, 3), "
-                    f"got {vertices.shape}"
-                )
+                result.add_error(f"{path}/vertices: expected shape (N, 3), got {vertices.shape}")
             else:
                 n_vertices = vertices.shape[0]
                 data = vertices[:]
@@ -568,24 +567,18 @@ def _validate_mesh_datasets(
         triangles = grp[GRP_TRIANGLES]
         if isinstance(triangles, h5py.Dataset):
             if triangles.ndim != 2 or triangles.shape[1] != 3:
-                result.add_error(
-                    f"{path}/triangles: expected shape (M, 3), "
-                    f"got {triangles.shape}"
-                )
+                result.add_error(f"{path}/triangles: expected shape (M, 3), got {triangles.shape}")
             else:
                 tri_data = triangles[:]
                 if np.any(tri_data < 0):
-                    result.add_error(
-                        f"{path}/triangles: contains negative indices"
-                    )
+                    result.add_error(f"{path}/triangles: contains negative indices")
                 elif (
                     check_global_indices
                     and n_vertices is not None
                     and np.any(tri_data >= n_vertices)
                 ):
                     result.add_error(
-                        f"{path}/triangles: contains indices >= "
-                        f"vertex count ({n_vertices})"
+                        f"{path}/triangles: contains indices >= vertex count ({n_vertices})"
                     )
 
 
@@ -674,9 +667,7 @@ def _validate_soma_group(soma_grp: h5py.Group, check_data_integrity: bool) -> Va
             result.add_error(f"/soma/meshes/{name}: missing '{GRP_TRIANGLES}' dataset")
 
         if check_data_integrity:
-            _validate_mesh_datasets(
-                item, f"/soma/meshes/{name}", result
-            )
+            _validate_mesh_datasets(item, f"/soma/meshes/{name}", result)
 
     return result
 

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -1,0 +1,790 @@
+"""Validates the structure and data integrity of a morphology-with-spines HDF5 file.
+
+This module provides a public API function validate_morph_with_spines_file() that
+checks whether a given HDF5 file conforms to the morph-spines format specification.
+
+Structure checks (always performed):
+    - File exists, is a file, and is a valid HDF5.
+    - Mandatory top-level groups present: '/morphology', '/edges' and '/spines'.
+    - /morphology/{name}: is a group with 'points' and 'structure' datasets.
+    - /edges/{name}: is a group with 'metadata' subgroup containing 'version'
+      attribute; 'version' is (1, 0); all mandatory column datasets present
+      (spines table).
+    - /spines/skeletons/{name}: is a group with 'points' and 'structure' datasets.
+    - /spines/meshes/{name} (optional): if present, it contains 'vertices', 'triangles'
+      and 'offsets' datasets.
+    - /soma/meshes/{name} (optional): if present, it contains 'vertices' and 'triangles'
+      datasets.
+    - Warnings for unexpected top-level groups or unknown spine table columns.
+
+Data integrity checks (when check_data_integrity=True):
+    - /morphology points: shape (N, 4), float32 dtype, no NaN/Inf, non-empty.
+    - /morphology structure: shape (M, 3), non-empty.
+    - /edges column dtypes match the spec of the spine table (float, int, string).
+    - /edges float columns: no NaN/Inf values.
+    - /edges dataset lengths are consistent (all same size).
+    - /edges afferent_section_pos values in [0, 1].
+    - /edges spine_length values > 0.
+    - /edges afferent_segment_offset values >= 0.
+    - /edges spine_morphology references existing /spines/skeletons groups.
+    - /spines/skeletons points: shape (N, 4), float32 dtype, no NaN/Inf, non-empty.
+    - /spines/skeletons structure: shape (M, 3), non-empty.
+    - /spines/meshes vertices: shape (N, 3), no NaN/Inf.
+    - /spines/meshes triangles: shape (M, 3), no negative indices.
+    - /spines/meshes offsets: shape (K, 2|3), non-decreasing, first row is (0, 0).
+    - /spines/meshes per-spine triangle indices < local vertex count (via offsets).
+    - /soma/meshes vertices: shape (N, 3), no NaN/Inf.
+    - /soma/meshes triangles: shape (M, 3), no negative indices,
+      indices < vertex count.
+    - Cross-group: /edges neuron names subgroups exist in /morphology.
+    - Cross-group: spine_morphology values reference existing /spines/meshes groups.
+    - Cross-group: spine_id values are valid indices into skeleton root sections
+      and mesh offsets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from morph_spines.core.h5_schema import (
+    ATT_VERSION,
+    GRP_EDGES,
+    GRP_HEAD_NECK_VALUES,
+    GRP_MESHES,
+    GRP_METADATA,
+    GRP_MORPH,
+    GRP_OFFSETS,
+    GRP_SKELETONS,
+    GRP_SOMA,
+    GRP_SPINES,
+    GRP_TRIANGLES,
+    GRP_VERTICES,
+    MANDATORY_COLUMNS,
+    OPTIONAL_COLUMNS,
+    SPINE_TABLE_VER_H5_DATASETS,
+)
+
+
+@dataclass
+class ValidationResult:
+    """Container for validation results.
+
+    Attributes:
+        is_valid: True if no errors were found (warnings are allowed).
+        data_integrity_checked: Whether data-level integrity checks were performed
+            in addition to the structural validation.
+        errors: Critical issues that make the file non-conformant.
+        warnings: Non-critical issues or deviations from best practices.
+        info: Informational messages about what was found.
+    """
+
+    is_valid: bool = True
+    data_integrity_checked: bool = False
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+
+    def add_error(self, msg: str) -> None:
+        """Record a validation error and mark the result as invalid."""
+        self.errors.append(msg)
+        self.is_valid = False
+
+    def add_warning(self, msg: str) -> None:
+        """Record a non-critical warning."""
+        self.warnings.append(msg)
+
+    def add_info(self, msg: str) -> None:
+        """Record an informational message."""
+        self.info.append(msg)
+
+    def merge(self, other: ValidationResult) -> None:
+        """Merge another ValidationResult into this one."""
+        self.errors.extend(other.errors)
+        self.warnings.extend(other.warnings)
+        self.info.extend(other.info)
+        if not other.is_valid:
+            self.is_valid = False
+
+    def __str__(self) -> str:
+        """Return a human-readable summary of the validation result."""
+        status = "VALID" if self.is_valid else "INVALID"
+        scope = "structure + data integrity" if self.data_integrity_checked else "structure only"
+        lines = [f"Validation result: {status} (checked: {scope})"]
+        if self.info:
+            lines.append(f"  Info ({len(self.info)}):")
+            for msg in self.info:
+                lines.append(f"    - {msg}")
+        if self.warnings:
+            lines.append(f"  Warnings ({len(self.warnings)}):")
+            for msg in self.warnings:
+                lines.append(f"    - {msg}")
+        if self.errors:
+            lines.append(f"  Errors ({len(self.errors)}):")
+            for msg in self.errors:
+                lines.append(f"    - {msg}")
+        return "\n".join(lines)
+
+
+def validate_morph_with_spines_file(
+    filepath: str | Path,
+    check_data_integrity: bool = False,
+) -> ValidationResult:
+    """Validate a morphology-with-spines HDF5 file.
+
+    By default, checks only file structure: the presence and nesting of expected HDF5
+    groups, datasets, and metadata attributes. When check_data_integrity is True,
+    also validates dataset shapes, dtypes, value ranges, and cross-group consistency.
+
+    Args:
+        filepath: Path to the HDF5 file to validate.
+        check_data_integrity: If True, perform additional data-level checks such as
+            dataset shapes, dtype compatibility, value ranges, NaN/Inf detection,
+            and cross-group referential integrity.
+
+    Returns:
+        A ValidationResult with errors, warnings, and information messages.
+    """
+    filepath = Path(filepath)
+    result = ValidationResult(data_integrity_checked=check_data_integrity)
+
+    # Basic file checks
+    if not filepath.exists():
+        result.add_error(f"File not found: {filepath}")
+        return result
+
+    if not filepath.is_file():
+        result.add_error(f"Path is not a file: {filepath}")
+        return result
+
+    # File structure checks
+    try:
+        h5 = h5py.File(filepath, "r")
+    except OSError as e:
+        result.add_error(f"Cannot open file as HDF5: {e}")
+        return result
+
+    with h5:
+        # Validate top-level groups
+        top_keys = set(h5.keys())
+
+        # /morphology is mandatory
+        if GRP_MORPH not in top_keys:
+            result.add_error(f"Missing mandatory top-level group: /{GRP_MORPH}")
+        else:
+            result.merge(_validate_morphology_group(h5[GRP_MORPH], check_data_integrity))
+
+        # /edges is mandatory
+        if GRP_EDGES not in top_keys:
+            result.add_error(f"Missing mandatory top-level group: /{GRP_EDGES}")
+        else:
+            result.merge(_validate_edges_group(h5[GRP_EDGES], check_data_integrity))
+
+        # /spines is mandatory (skeletons required, meshes optional)
+        if GRP_SPINES not in top_keys:
+            result.add_error(f"Missing mandatory top-level group: /{GRP_SPINES}")
+        else:
+            result.merge(_validate_spines_group(h5[GRP_SPINES], check_data_integrity))
+
+        # /soma is optional
+        if GRP_SOMA in top_keys:
+            result.merge(_validate_soma_group(h5[GRP_SOMA], check_data_integrity))
+        else:
+            result.add_info(f"Optional group /{GRP_SOMA} not present")
+
+        # Check for unexpected top-level groups
+        expected_top = {GRP_EDGES, GRP_MORPH, GRP_SOMA, GRP_SPINES}
+        unexpected = top_keys - expected_top
+        if unexpected:
+            result.add_warning(f"Unexpected top-level groups: {sorted(unexpected)}")
+
+        # Cross-group integrity (only with data integrity checks)
+        if check_data_integrity and result.is_valid:
+            result.merge(_validate_cross_group_integrity(h5))
+
+    return result
+
+
+def _validate_h5v1_morphology_subgroup(
+    grp: h5py.Group, path: str, check_data_integrity: bool, result: ValidationResult
+) -> None:
+    """Validate an H5v1 morphology subgroup (points, structure, metadata).
+
+    This is the common structure shared by /morphology/{name} and
+    /spines/skeletons/{name} groups.
+
+    Args:
+        grp: The HDF5 group to validate.
+        path: Display path for error messages (e.g. "/morphology/neuron_01").
+        check_data_integrity: Whether to check dataset shapes, dtypes, and values.
+        result: ValidationResult to accumulate findings into.
+    """
+    keys = set(grp.keys())
+
+    if "points" not in keys:
+        result.add_error(f"{path}: missing 'points' dataset")
+    if "structure" not in keys:
+        result.add_error(f"{path}: missing 'structure' dataset")
+    if GRP_METADATA not in keys:
+        result.add_warning(f"{path}: missing '{GRP_METADATA}' subgroup")
+
+    if check_data_integrity:
+        if "points" in keys:
+            points = grp["points"]
+            if not isinstance(points, h5py.Dataset):
+                result.add_error(f"{path}/points is not a dataset")
+            elif points.ndim != 2 or points.shape[1] != 4:
+                result.add_error(f"{path}/points: expected shape (N, 4), got {points.shape}")
+            elif points.shape[0] == 0:
+                result.add_error(f"{path}/points: dataset is empty")
+            else:
+                if points.dtype != np.float32:
+                    result.add_warning(f"{path}/points: expected float32, got {points.dtype}")
+                data = points[:]
+                if np.any(np.isnan(data)):
+                    result.add_error(f"{path}/points: contains NaN values")
+                if np.any(np.isinf(data)):
+                    result.add_error(f"{path}/points: contains Inf values")
+
+        if "structure" in keys:
+            structure = grp["structure"]
+            if not isinstance(structure, h5py.Dataset):
+                result.add_error(f"{path}/structure is not a dataset")
+            elif structure.ndim != 2 or structure.shape[1] != 3:
+                result.add_error(f"{path}/structure: expected shape (M, 3), got {structure.shape}")
+            elif structure.shape[0] == 0:
+                result.add_error(f"{path}/structure: dataset is empty")
+
+
+def _validate_morphology_group(
+    morph_grp: h5py.Group, check_data_integrity: bool
+) -> ValidationResult:
+    """Validate the /morphology group structure and data."""
+    result = ValidationResult()
+
+    neuron_names = list(morph_grp.keys())
+    if len(neuron_names) == 0:
+        result.add_error("/morphology group is empty (no neuron subgroups)")
+        return result
+
+    result.add_info(f"/morphology contains {len(neuron_names)} neuron(s): {neuron_names}")
+
+    for name in neuron_names:
+        item = morph_grp[name]
+        if not isinstance(item, h5py.Group):
+            result.add_error(f"/morphology/{name} is not a group")
+            continue
+
+        _validate_h5v1_morphology_subgroup(
+            item, f"/morphology/{name}", check_data_integrity, result
+        )
+
+    return result
+
+
+def _validate_edges_group(edges_grp: h5py.Group, check_data_integrity: bool) -> ValidationResult:
+    """Validate the /edges group structure and data."""
+    result = ValidationResult()
+
+    neuron_names = list(edges_grp.keys())
+    if len(neuron_names) == 0:
+        result.add_error("/edges group is empty (no neuron subgroups)")
+        return result
+
+    result.add_info(f"/edges contains {len(neuron_names)} spine table(s): {neuron_names}")
+
+    for name in neuron_names:
+        item = edges_grp[name]
+        if not isinstance(item, h5py.Group):
+            result.add_error(f"/edges/{name} is not a group")
+            continue
+
+        keys = set(item.keys())
+
+        # Metadata subgroup is mandatory
+        if GRP_METADATA not in keys:
+            result.add_error(f"/edges/{name}: missing '{GRP_METADATA}' subgroup")
+        else:
+            metadata = item[GRP_METADATA]
+            if not isinstance(metadata, h5py.Group):
+                result.add_error(f"/edges/{name}/{GRP_METADATA} is not a group")
+            elif ATT_VERSION not in metadata.attrs:
+                result.add_error(f"/edges/{name}/{GRP_METADATA}: missing '{ATT_VERSION}' attribute")
+            else:
+                version = tuple(metadata.attrs[ATT_VERSION])
+                if version != SPINE_TABLE_VER_H5_DATASETS:
+                    result.add_error(
+                        f"/edges/{name}: unsupported spine table version {version}, "
+                        f"expected {SPINE_TABLE_VER_H5_DATASETS}"
+                    )
+
+        # Check mandatory columns are present as datasets
+        dataset_keys = {k for k in keys if k != GRP_METADATA}
+        missing_cols = set(MANDATORY_COLUMNS.keys()) - dataset_keys
+        if missing_cols:
+            result.add_error(
+                f"/edges/{name}: missing mandatory column datasets: {sorted(missing_cols)}"
+            )
+
+        # Check for unknown columns
+        known_cols = set(MANDATORY_COLUMNS.keys()) | set(OPTIONAL_COLUMNS.keys())
+        unknown_cols = dataset_keys - known_cols
+        if unknown_cols:
+            result.add_warning(
+                f"/edges/{name}: unknown column datasets (not in spec): {sorted(unknown_cols)}"
+            )
+
+        if check_data_integrity:
+            _validate_edges_data_integrity(item, name, result)
+
+    return result
+
+
+def _validate_edges_data_integrity(
+    spine_table_grp: h5py.Group, name: str, result: ValidationResult
+) -> None:
+    """Validate data integrity of datasets within an /edges/{name} group."""
+    all_columns = {**MANDATORY_COLUMNS, **OPTIONAL_COLUMNS}
+    dataset_keys = {k for k in spine_table_grp.keys() if k != GRP_METADATA}
+
+    # All datasets must have the same length
+    lengths = {}
+    for col_name in dataset_keys:
+        item = spine_table_grp[col_name]
+        if not isinstance(item, h5py.Dataset):
+            result.add_error(f"/edges/{name}/{col_name} is not a dataset")
+            continue
+        if item.ndim > 1:
+            result.add_error(f"/edges/{name}/{col_name}: must be 1D, got shape {item.shape}")
+            continue
+        length = item.shape[0] if item.shape != () else 1
+        lengths[col_name] = length
+
+    unique_lengths = set(lengths.values())
+    if len(unique_lengths) > 1:
+        result.add_error(f"/edges/{name}: datasets have inconsistent lengths: {lengths}")
+
+    # Check dtypes for known columns
+    for col_name in dataset_keys:
+        if col_name not in all_columns:
+            continue
+        item = spine_table_grp[col_name]
+        if not isinstance(item, h5py.Dataset):
+            continue
+
+        expected_kind = all_columns[col_name]
+        actual_kind = item.dtype.kind
+
+        if expected_kind == "str":
+            if actual_kind not in ("O", "U", "S"):
+                result.add_error(
+                    f"/edges/{name}/{col_name}: expected string type, got dtype '{item.dtype}'"
+                )
+        elif expected_kind == "f":
+            if actual_kind not in ("f", "i", "u"):
+                result.add_error(
+                    f"/edges/{name}/{col_name}: expected numeric type, got dtype '{item.dtype}'"
+                )
+            else:
+                data = item[:]
+                if np.any(np.isnan(data)):
+                    result.add_error(f"/edges/{name}/{col_name}: contains NaN values")
+                if np.any(np.isinf(data)):
+                    result.add_error(f"/edges/{name}/{col_name}: contains Inf values")
+        elif expected_kind in ("i", "ui"):
+            if actual_kind not in ("i", "u", "f"):
+                result.add_error(
+                    f"/edges/{name}/{col_name}: expected integer type, got dtype '{item.dtype}'"
+                )
+
+    # Validate afferent_section_pos is in [0, 1]
+    if "afferent_section_pos" in dataset_keys:
+        data = spine_table_grp["afferent_section_pos"][:]
+        out_of_range = int(np.sum((data < 0) | (data > 1)))
+        if out_of_range > 0:
+            result.add_error(
+                f"/edges/{name}/afferent_section_pos: {out_of_range} values outside [0, 1]"
+            )
+
+    # Validate spine_length > 0
+    if "spine_length" in dataset_keys:
+        data = spine_table_grp["spine_length"][:]
+        n_invalid = int(np.sum(data <= 0))
+        if n_invalid > 0:
+            result.add_error(f"/edges/{name}/spine_length: {n_invalid} values <= 0")
+
+    # Validate afferent_segment_offset >= 0
+    if "afferent_segment_offset" in dataset_keys:
+        data = spine_table_grp["afferent_segment_offset"][:]
+        n_negative = int(np.sum(data < 0))
+        if n_negative > 0:
+            result.add_error(f"/edges/{name}/afferent_segment_offset: {n_negative} negative values")
+
+    # Validate spine_morphology references existing /spines/skeletons subgroups
+    if "spine_morphology" in dataset_keys:
+        spine_morph_values = set(spine_table_grp["spine_morphology"][:].astype(str))
+        h5_file = spine_table_grp.file
+        skeletons_path = f"{GRP_SPINES}/{GRP_SKELETONS}"
+        if skeletons_path in h5_file:
+            skeleton_names = set(h5_file[skeletons_path].keys())
+            missing = spine_morph_values - skeleton_names
+            if missing:
+                result.add_error(
+                    f"/edges/{name}/spine_morphology: references groups not in "
+                    f"/{skeletons_path}: {sorted(missing)}"
+                )
+
+
+def _validate_spines_group(spines_grp: h5py.Group, check_data_integrity: bool) -> ValidationResult:
+    """Validate the /spines group structure and data."""
+    result = ValidationResult()
+
+    keys = set(spines_grp.keys())
+
+    # /spines/skeletons is mandatory
+    if GRP_SKELETONS not in keys:
+        result.add_error(f"/spines: missing mandatory subgroup '{GRP_SKELETONS}'")
+    else:
+        result.merge(_validate_spines_skeletons(spines_grp[GRP_SKELETONS], check_data_integrity))
+
+    # /spines/meshes is optional
+    if GRP_MESHES in keys:
+        result.merge(_validate_spines_meshes(spines_grp[GRP_MESHES], check_data_integrity))
+    else:
+        result.add_info("/spines/meshes not present (optional)")
+
+    # Unexpected subgroups
+    expected = {GRP_SKELETONS, GRP_MESHES}
+    unexpected = keys - expected
+    if unexpected:
+        result.add_warning(f"/spines: unexpected subgroups: {sorted(unexpected)}")
+
+    return result
+
+
+def _validate_spines_skeletons(
+    skeletons_grp: h5py.Group, check_data_integrity: bool
+) -> ValidationResult:
+    """Validate /spines/skeletons subgroups."""
+    result = ValidationResult()
+
+    group_names = list(skeletons_grp.keys())
+    if len(group_names) == 0:
+        result.add_error("/spines/skeletons is empty (no skeleton groups)")
+        return result
+
+    result.add_info(f"/spines/skeletons contains {len(group_names)} group(s): {group_names}")
+
+    for name in group_names:
+        item = skeletons_grp[name]
+        if not isinstance(item, h5py.Group):
+            result.add_error(f"/spines/skeletons/{name} is not a group")
+            continue
+
+        _validate_h5v1_morphology_subgroup(
+            item, f"/spines/skeletons/{name}", check_data_integrity, result
+        )
+
+    return result
+
+
+def _validate_spines_meshes(meshes_grp: h5py.Group, check_data_integrity: bool) -> ValidationResult:
+    """Validate /spines/meshes subgroups."""
+    result = ValidationResult()
+
+    group_names = list(meshes_grp.keys())
+    if len(group_names) == 0:
+        result.add_warning("/spines/meshes is empty (no mesh groups)")
+        return result
+
+    result.add_info(f"/spines/meshes contains {len(group_names)} group(s): {group_names}")
+
+    for name in group_names:
+        item = meshes_grp[name]
+        if not isinstance(item, h5py.Group):
+            result.add_error(f"/spines/meshes/{name} is not a group")
+            continue
+
+        keys = set(item.keys())
+
+        # Required datasets within a mesh group
+        if GRP_VERTICES not in keys:
+            result.add_error(f"/spines/meshes/{name}: missing '{GRP_VERTICES}' dataset")
+        if GRP_TRIANGLES not in keys:
+            result.add_error(f"/spines/meshes/{name}: missing '{GRP_TRIANGLES}' dataset")
+        if GRP_OFFSETS not in keys:
+            result.add_error(f"/spines/meshes/{name}: missing '{GRP_OFFSETS}' dataset")
+
+        # head_neck_values is optional
+        if GRP_HEAD_NECK_VALUES in keys:
+            result.add_info(f"/spines/meshes/{name}: head_neck_values present")
+
+        if check_data_integrity:
+            _validate_spine_mesh_data(item, name, result)
+
+    return result
+
+
+def _validate_mesh_datasets(
+    grp: h5py.Group, path: str, result: ValidationResult,
+    check_global_indices: bool = True,
+) -> None:
+    """Validate vertices and triangles datasets within a mesh group.
+
+    Checks shape, NaN/Inf in vertices, negative triangle indices, and
+    optionally triangle indices vs total vertex count.
+
+    Args:
+        grp: HDF5 group containing 'vertices' and 'triangles' datasets.
+        path: Display path for error messages.
+        result: ValidationResult to accumulate findings into.
+        check_global_indices: If True, verify triangle indices < total vertex
+            count. Set to False for spine meshes where indices are local
+            per spine and validated separately via offsets.
+    """
+    keys = set(grp.keys())
+    n_vertices = None
+
+    if GRP_VERTICES in keys:
+        vertices = grp[GRP_VERTICES]
+        if isinstance(vertices, h5py.Dataset):
+            if vertices.ndim != 2 or vertices.shape[1] != 3:
+                result.add_error(
+                    f"{path}/vertices: expected shape (N, 3), "
+                    f"got {vertices.shape}"
+                )
+            else:
+                n_vertices = vertices.shape[0]
+                data = vertices[:]
+                if np.any(np.isnan(data)):
+                    result.add_error(f"{path}/vertices: contains NaN values")
+                elif np.any(np.isinf(data)):
+                    result.add_error(f"{path}/vertices: contains Inf values")
+
+    if GRP_TRIANGLES in keys:
+        triangles = grp[GRP_TRIANGLES]
+        if isinstance(triangles, h5py.Dataset):
+            if triangles.ndim != 2 or triangles.shape[1] != 3:
+                result.add_error(
+                    f"{path}/triangles: expected shape (M, 3), "
+                    f"got {triangles.shape}"
+                )
+            else:
+                tri_data = triangles[:]
+                if np.any(tri_data < 0):
+                    result.add_error(
+                        f"{path}/triangles: contains negative indices"
+                    )
+                elif (
+                    check_global_indices
+                    and n_vertices is not None
+                    and np.any(tri_data >= n_vertices)
+                ):
+                    result.add_error(
+                        f"{path}/triangles: contains indices >= "
+                        f"vertex count ({n_vertices})"
+                    )
+
+
+def _validate_spine_mesh_data(mesh_grp: h5py.Group, name: str, result: ValidationResult) -> None:
+    """Validate data integrity within a single /spines/meshes/{name} group."""
+    keys = set(mesh_grp.keys())
+    prefix = f"/spines/meshes/{name}"
+
+    _validate_mesh_datasets(mesh_grp, prefix, result, check_global_indices=False)
+
+    # Offsets: shape (num_spines+1, 2) or (num_spines+1, 3)
+    if GRP_OFFSETS in keys:
+        offsets = mesh_grp[GRP_OFFSETS]
+        if isinstance(offsets, h5py.Dataset):
+            if offsets.ndim != 2 or offsets.shape[1] not in (2, 3):
+                result.add_error(
+                    f"{prefix}/offsets: expected shape (K, 2) or (K, 3), got {offsets.shape}"
+                )
+            elif offsets.shape[0] < 2:
+                result.add_error(
+                    f"{prefix}/offsets: must have at least 2 rows (got {offsets.shape[0]})"
+                )
+            else:
+                off_data = offsets[:]
+                # First row should be zeros
+                if not np.all(off_data[0, :2] == 0):
+                    result.add_warning(f"{prefix}/offsets: first row is not (0, 0, ...)")
+                # Offsets should be non-decreasing
+                if np.any(np.diff(off_data[:, 0]) < 0):
+                    result.add_error(f"{prefix}/offsets: vertex offsets are not non-decreasing")
+                if np.any(np.diff(off_data[:, 1]) < 0):
+                    result.add_error(f"{prefix}/offsets: triangle offsets are not non-decreasing")
+
+                # Per-spine triangle index check: indices are local to each
+                # spine's vertex slice, so they must be < (vertex_end - vertex_start)
+                if GRP_TRIANGLES in keys and GRP_VERTICES in keys:
+                    tri_data = mesh_grp[GRP_TRIANGLES][:]
+                    n_spines = off_data.shape[0] - 1
+                    for i in range(n_spines):
+                        v_start, v_end = off_data[i, 0], off_data[i + 1, 0]
+                        t_start, t_end = off_data[i, 1], off_data[i + 1, 1]
+                        n_local_verts = v_end - v_start
+                        if t_end > t_start and n_local_verts > 0:
+                            spine_tris = tri_data[t_start:t_end]
+                            if np.any(spine_tris >= n_local_verts):
+                                result.add_error(
+                                    f"{prefix}: spine {i} has triangle "
+                                    f"indices >= local vertex count "
+                                    f"({n_local_verts})"
+                                )
+                                break  # one error is enough
+
+
+def _validate_soma_group(soma_grp: h5py.Group, check_data_integrity: bool) -> ValidationResult:
+    """Validate the /soma group structure and data."""
+    result = ValidationResult()
+
+    keys = set(soma_grp.keys())
+
+    if GRP_MESHES not in keys:
+        result.add_warning(f"/soma: missing '{GRP_MESHES}' subgroup")
+        return result
+
+    meshes_grp = soma_grp[GRP_MESHES]
+    if not isinstance(meshes_grp, h5py.Group):
+        result.add_error(f"/soma/{GRP_MESHES} is not a group")
+        return result
+
+    neuron_names = list(meshes_grp.keys())
+    if len(neuron_names) == 0:
+        result.add_warning("/soma/meshes is empty (no soma meshes)")
+        return result
+
+    result.add_info(f"/soma/meshes contains {len(neuron_names)} mesh(es): {neuron_names}")
+
+    for name in neuron_names:
+        item = meshes_grp[name]
+        if not isinstance(item, h5py.Group):
+            result.add_error(f"/soma/meshes/{name} is not a group")
+            continue
+
+        keys_inner = set(item.keys())
+        if GRP_VERTICES not in keys_inner:
+            result.add_error(f"/soma/meshes/{name}: missing '{GRP_VERTICES}' dataset")
+        if GRP_TRIANGLES not in keys_inner:
+            result.add_error(f"/soma/meshes/{name}: missing '{GRP_TRIANGLES}' dataset")
+
+        if check_data_integrity:
+            _validate_mesh_datasets(
+                item, f"/soma/meshes/{name}", result
+            )
+
+    return result
+
+
+def _validate_cross_group_integrity(h5: h5py.File) -> ValidationResult:
+    """Validate referential integrity across groups.
+
+    Checks that:
+    - Neuron names in /edges reference existing entries in /morphology.
+    - spine_morphology values in /edges reference existing /spines/meshes subgroups
+      (if meshes are present).
+    - spine_id values in /edges are valid indices into the corresponding
+      /spines/skeletons (root section count) and /spines/meshes (offset count).
+    """
+    result = ValidationResult()
+
+    # Neuron names consistency
+    morph_names = set(h5[GRP_MORPH].keys()) if GRP_MORPH in h5 else set()
+    edges_names = set(h5[GRP_EDGES].keys()) if GRP_EDGES in h5 else set()
+    mesh_names = (
+        set(h5[f"{GRP_SPINES}/{GRP_MESHES}"].keys())
+        if GRP_SPINES in h5 and GRP_MESHES in h5[GRP_SPINES]
+        else set()
+    )
+
+    # /edges neuron names should exist in /morphology
+    orphan_edges = edges_names - morph_names
+    if orphan_edges:
+        result.add_error(f"/edges references neuron(s) not in /morphology: {sorted(orphan_edges)}")
+
+    # Check spine_morphology references in /edges point to valid meshes
+    # (skeleton references are already checked per-edge in _validate_edges_data_integrity)
+    if mesh_names:
+        for edge_name in edges_names:
+            edge_grp = h5[GRP_EDGES][edge_name]
+            if not isinstance(edge_grp, h5py.Group):
+                continue
+            if "spine_morphology" not in edge_grp:
+                continue
+
+            spine_morph_dset = edge_grp["spine_morphology"]
+            if not isinstance(spine_morph_dset, h5py.Dataset):
+                continue
+
+            spine_morph_values = set(spine_morph_dset[:].astype(str))
+
+            missing_meshes = spine_morph_values - mesh_names
+            if missing_meshes:
+                result.add_warning(
+                    f"/edges/{edge_name}/spine_morphology references mesh groups "
+                    f"not in /spines/meshes: {sorted(missing_meshes)}"
+                )
+
+    # Check that spine_id values are valid indices into skeletons and meshes
+    for edge_name in edges_names:
+        edge_grp = h5[GRP_EDGES][edge_name]
+        if not isinstance(edge_grp, h5py.Group):
+            continue
+        if "spine_morphology" not in edge_grp or "spine_id" not in edge_grp:
+            continue
+
+        spine_morph_dset = edge_grp["spine_morphology"]
+        spine_id_dset = edge_grp["spine_id"]
+        if not isinstance(spine_morph_dset, h5py.Dataset):
+            continue
+        if not isinstance(spine_id_dset, h5py.Dataset):
+            continue
+
+        morph_values = spine_morph_dset[:].astype(str)
+        id_values = spine_id_dset[:]
+
+        # Group spine_ids by their spine_morphology to check bounds per group
+        unique_morphs = set(morph_values)
+        for spine_morph in unique_morphs:
+            mask = morph_values == spine_morph
+            ids_for_morph = id_values[mask]
+            max_id = int(np.max(ids_for_morph))
+
+            # Check against skeleton root sections
+            skel_path = f"{GRP_SPINES}/{GRP_SKELETONS}/{spine_morph}"
+            if skel_path in h5:
+                skel_grp = h5[skel_path]
+                if "structure" in skel_grp:
+                    structure = skel_grp["structure"]
+                    if isinstance(structure, h5py.Dataset) and structure.ndim == 2:
+                        # Root sections have parent == -1 (column index 2)
+                        n_root_sections = int(np.sum(structure[:, 2] == -1))
+                        if max_id >= n_root_sections:
+                            result.add_error(
+                                f"/edges/{edge_name}: spine_id={max_id} for "
+                                f"spine_morphology='{spine_morph}' exceeds skeleton "
+                                f"root section count ({n_root_sections})"
+                            )
+
+            # Check against mesh offsets
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{spine_morph}"
+            if mesh_path in h5:
+                mesh_grp = h5[mesh_path]
+                if GRP_OFFSETS in mesh_grp:
+                    offsets = mesh_grp[GRP_OFFSETS]
+                    if isinstance(offsets, h5py.Dataset) and offsets.ndim == 2:
+                        # Number of spines in mesh = offsets rows - 1
+                        n_mesh_spines = offsets.shape[0] - 1
+                        if max_id >= n_mesh_spines:
+                            result.add_error(
+                                f"/edges/{edge_name}: spine_id={max_id} for "
+                                f"spine_morphology='{spine_morph}' exceeds mesh "
+                                f"offset count ({n_mesh_spines})"
+                            )
+
+    return result

--- a/src/morph_spines/utils/morph_spine_validator.py
+++ b/src/morph_spines/utils/morph_spine_validator.py
@@ -10,13 +10,14 @@ Structure checks (always performed):
     - /edges/{name}: is a group with 'metadata' subgroup containing 'version'
       attribute; 'version' is (1, 0); all mandatory column datasets present
       (spines table); spine_morphology references existing /spines/skeletons
-      groups.
+      groups (error) and /spines/meshes groups if present (warning).
     - /spines/skeletons/{name}: is a group with 'points' and 'structure' datasets.
     - /spines/meshes/{name} (optional): if present, it contains 'vertices', 'triangles'
       and 'offsets' datasets.
     - /soma/meshes/{name} (optional): if present, it contains 'vertices' and 'triangles'
       datasets.
     - Warnings for unexpected top-level groups or unknown spine table columns.
+    - /edges neuron names must exist in /morphology.
 
 Data integrity checks (when check_data_integrity=True):
     - /morphology points: shape (N, 4), float32 dtype, no NaN/Inf, non-empty.
@@ -40,8 +41,6 @@ Data integrity checks (when check_data_integrity=True):
     - /soma/meshes vertices: shape (N, 3), no NaN/Inf.
     - /soma/meshes triangles: shape (M, 3), no negative indices,
       indices < vertex count.
-    - Cross-group: /edges neuron names subgroups exist in /morphology.
-    - Cross-group: spine_morphology values reference existing /spines/meshes groups.
     - Cross-group: spine_id values are valid indices into skeleton root sections
       and mesh offsets.
     - Cross-group: afferent_section_id values are valid section indices in
@@ -240,7 +239,17 @@ def validate_morph_with_spines_file(
         if unexpected:
             result.add_warning(f"Unexpected top-level groups: {sorted(unexpected)}")
 
-        # Cross-group integrity (only with data integrity checks)
+        # /edges neuron names must exist in /morphology
+        if GRP_MORPH in top_keys and GRP_EDGES in top_keys:
+            morph_names = set(h5[GRP_MORPH].keys())
+            edges_names = set(h5[GRP_EDGES].keys())
+            orphan = edges_names - morph_names
+            if orphan:
+                result.add_error(
+                    f"/edges references neuron(s) not in /morphology: {sorted(orphan)}"
+                )
+
+        # Cross-group data integrity (only with data integrity checks)
         if check_data_integrity and result.is_valid:
             result.merge(_validate_cross_group_integrity(h5))
 
@@ -381,16 +390,26 @@ def _validate_edges_group(edges_grp: h5py.Group, check_data_integrity: bool) -> 
             spine_morph_dset = item["spine_morphology"]
             if isinstance(spine_morph_dset, h5py.Dataset):
                 h5_file = item.file
+                values = set(spine_morph_dset[:].astype(str))
+
                 skeletons_path = f"{GRP_SPINES}/{GRP_SKELETONS}"
                 if skeletons_path in h5_file:
-                    skeleton_names = set(h5_file[skeletons_path].keys())
-                    values = set(spine_morph_dset[:].astype(str))
-                    missing = values - skeleton_names
+                    missing = values - set(h5_file[skeletons_path].keys())
                     if missing:
                         result.add_error(
                             f"/edges/{name}/spine_morphology: "
                             f"references groups not in "
                             f"/{skeletons_path}: {sorted(missing)}"
+                        )
+
+                meshes_path = f"{GRP_SPINES}/{GRP_MESHES}"
+                if meshes_path in h5_file:
+                    missing = values - set(h5_file[meshes_path].keys())
+                    if missing:
+                        result.add_warning(
+                            f"/edges/{name}/spine_morphology: "
+                            f"references groups not in "
+                            f"/{meshes_path}: {sorted(missing)}"
                         )
 
         if check_data_integrity:
@@ -720,9 +739,6 @@ def _validate_cross_group_integrity(h5: h5py.File) -> ValidationResult:
     """Validate referential integrity across groups.
 
     Checks that:
-    - Neuron names in /edges reference existing entries in /morphology.
-    - spine_morphology values in /edges reference existing /spines/meshes subgroups
-      (if meshes are present).
     - spine_id values in /edges are valid indices into the corresponding
       /spines/skeletons (root section count) and /spines/meshes (offset count).
     - afferent_section_id values in /edges are valid section indices in
@@ -730,42 +746,7 @@ def _validate_cross_group_integrity(h5: h5py.File) -> ValidationResult:
     """
     result = ValidationResult()
 
-    # Neuron names consistency
-    morph_names = set(h5[GRP_MORPH].keys()) if GRP_MORPH in h5 else set()
     edges_names = set(h5[GRP_EDGES].keys()) if GRP_EDGES in h5 else set()
-    mesh_names = (
-        set(h5[f"{GRP_SPINES}/{GRP_MESHES}"].keys())
-        if GRP_SPINES in h5 and GRP_MESHES in h5[GRP_SPINES]
-        else set()
-    )
-
-    # /edges neuron names should exist in /morphology
-    orphan_edges = edges_names - morph_names
-    if orphan_edges:
-        result.add_error(f"/edges references neuron(s) not in /morphology: {sorted(orphan_edges)}")
-
-    # Check spine_morphology references in /edges point to valid meshes
-    # (skeleton references are already checked per-edge in _validate_edges_data_integrity)
-    if mesh_names:
-        for edge_name in edges_names:
-            edge_grp = h5[GRP_EDGES][edge_name]
-            if not isinstance(edge_grp, h5py.Group):
-                continue
-            if "spine_morphology" not in edge_grp:
-                continue
-
-            spine_morph_dset = edge_grp["spine_morphology"]
-            if not isinstance(spine_morph_dset, h5py.Dataset):
-                continue
-
-            spine_morph_values = set(spine_morph_dset[:].astype(str))
-
-            missing_meshes = spine_morph_values - mesh_names
-            if missing_meshes:
-                result.add_warning(
-                    f"/edges/{edge_name}/spine_morphology references mesh groups "
-                    f"not in /spines/meshes: {sorted(missing_meshes)}"
-                )
 
     # Check that spine_id values are valid indices into skeletons and meshes
     for edge_name in edges_names:

--- a/src/morph_spines/utils/morph_spine_writer.py
+++ b/src/morph_spines/utils/morph_spine_writer.py
@@ -100,6 +100,23 @@ def validate_spine_table(spine_table: pd.DataFrame) -> None:
                 f"Unknown expected dtype kind '{expected_kind}' for column '{col_name}'"
             )
 
+    # Check value constraints for numeric columns (skip if dtype is wrong)
+    from morph_spines.utils.morph_spine_validator import check_column_values
+
+    _CHECKED_COLUMNS = (
+        "afferent_section_pos",
+        "spine_length",
+        "afferent_segment_offset",
+        "afferent_segment_id",
+        "spine_volume",
+        "spine_neck_diameter",
+    )
+    for col_name in _CHECKED_COLUMNS:
+        if col_name in spine_table.columns:
+            if spine_table[col_name].dtype.kind in ("f", "i", "u"):
+                for err in check_column_values(col_name, spine_table[col_name]):
+                    errors.append(f"Column '{col_name}': {err.split(': ', 1)[1]}")
+
     if errors:
         raise ValueError("Spine table validation failed:\n  - " + "\n  - ".join(errors))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,8 @@ def write_minimal_valid_file(filepath):
         soma_grp.create_dataset(GRP_VERTICES, data=SOMA_VERTICES)
         soma_grp.create_dataset(GRP_TRIANGLES, data=SOMA_TRIANGLES)
 
+    return filepath
+
 
 @pytest.fixture
 def minimal_valid_file(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from morph_spines.core.h5_schema import (
     GRP_VERTICES,
 )
 
-
 NEURON_NAME = "neuron_01"
 SPINE_MORPH_NAME = "neuron_01"
 N_SPINES = 3
@@ -29,37 +28,31 @@ SAMPLE_POINTS = np.array(
 SAMPLE_STRUCTURE = np.array([[0, 3, -1]], dtype=np.int32)
 
 # Mesh primitives
-SAMPLE_VERTICES = np.array(
-    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
-)
+SAMPLE_VERTICES = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
 SAMPLE_TRIANGLES = np.array([[0, 1, 2]], dtype=np.int32)
 
 # Spine skeletons (3 root sections for 3 spines)
 SKELETON_POINTS = np.array(
     [
-        [0, 0, 0, 0.1], [0, 1, 0, 0.1], [0, 2, 0, 0.1],
-        [0, 0, 1, 0.1], [0, 1, 1, 0.1],
-        [0, 0, 2, 0.1], [0, 1, 2, 0.1],
+        [0, 0, 0, 0.1],
+        [0, 1, 0, 0.1],
+        [0, 2, 0, 0.1],
+        [0, 0, 1, 0.1],
+        [0, 1, 1, 0.1],
+        [0, 0, 2, 0.1],
+        [0, 1, 2, 0.1],
     ],
     dtype=np.float32,
 )
-SKELETON_STRUCTURE = np.array(
-    [[0, 2, -1], [2, 2, -1], [4, 2, -1]], dtype=np.int32
-)
+SKELETON_STRUCTURE = np.array([[0, 2, -1], [2, 2, -1], [4, 2, -1]], dtype=np.int32)
 
 # Spine meshes (3 spines, each with its own [0,1,2] triangle into local vertices)
 SPINE_MESH_VERTICES = np.tile(SAMPLE_VERTICES, (N_SPINES, 1))
-SPINE_MESH_TRIANGLES = np.array(
-    [[0, 1, 2], [0, 1, 2], [0, 1, 2]], dtype=np.int32
-)
-SPINE_MESH_OFFSETS = np.array(
-    [[0, 0], [3, 1], [6, 2], [9, 3]], dtype=np.int32
-)
+SPINE_MESH_TRIANGLES = np.array([[0, 1, 2], [0, 1, 2], [0, 1, 2]], dtype=np.int32)
+SPINE_MESH_OFFSETS = np.array([[0, 0], [3, 1], [6, 2], [9, 3]], dtype=np.int32)
 
 # Soma mesh
-SOMA_VERTICES = np.array(
-    [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32
-)
+SOMA_VERTICES = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32)
 SOMA_TRIANGLES = np.array([[0, 1, 2], [1, 2, 3]], dtype=np.int32)
 
 # Edge/spine table column data
@@ -125,9 +118,7 @@ def write_minimal_valid_file(filepath):
     with consistent data for a single neuron with 3 spines.
     """
     # Build spine table from shared constants
-    spine_table = pd.DataFrame(
-        {col: arr.copy() for col, arr in EDGE_TABLE_DATA.items()}
-    )
+    spine_table = pd.DataFrame({col: arr.copy() for col, arr in EDGE_TABLE_DATA.items()})
     spine_table["spine_morphology"] = [SPINE_MORPH_NAME] * N_SPINES
     spine_table["spine_id"] = np.arange(N_SPINES, dtype=np.uint32)
 
@@ -141,32 +132,23 @@ def write_minimal_valid_file(filepath):
 
     # /edges
     from morph_spines.utils.morph_spine_writer import write_spine_table
+
     write_spine_table(str(filepath), NEURON_NAME, spine_table)
 
     # /spines and /soma
     with h5py.File(filepath, "a") as h5:
         # /spines/skeletons
-        skel_grp = h5.create_group(
-            f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
-        )
+        skel_grp = h5.create_group(f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}")
         skel_grp.create_dataset("points", data=SKELETON_POINTS)
         skel_grp.create_dataset("structure", data=SKELETON_STRUCTURE)
         skel_meta = skel_grp.create_group(GRP_METADATA)
         skel_meta.attrs["version"] = np.array([1, 3], dtype=np.uint32)
 
         # /spines/meshes
-        mesh_grp = h5.create_group(
-            f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-        )
-        mesh_grp.create_dataset(
-            GRP_VERTICES, data=SPINE_MESH_VERTICES, compression="gzip"
-        )
-        mesh_grp.create_dataset(
-            GRP_TRIANGLES, data=SPINE_MESH_TRIANGLES, compression="gzip"
-        )
-        mesh_grp.create_dataset(
-            GRP_OFFSETS, data=SPINE_MESH_OFFSETS, compression="gzip"
-        )
+        mesh_grp = h5.create_group(f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}")
+        mesh_grp.create_dataset(GRP_VERTICES, data=SPINE_MESH_VERTICES, compression="gzip")
+        mesh_grp.create_dataset(GRP_TRIANGLES, data=SPINE_MESH_TRIANGLES, compression="gzip")
+        mesh_grp.create_dataset(GRP_OFFSETS, data=SPINE_MESH_OFFSETS, compression="gzip")
 
         # /soma
         soma_grp = h5.create_group(f"soma/{GRP_MESHES}/{NEURON_NAME}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,182 @@
+"""Shared test fixtures and helpers for morph-spines tests."""
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from morph_spines.core.h5_schema import (
+    GRP_MESHES,
+    GRP_METADATA,
+    GRP_MORPH,
+    GRP_OFFSETS,
+    GRP_SKELETONS,
+    GRP_SPINES,
+    GRP_TRIANGLES,
+    GRP_VERTICES,
+)
+
+
+NEURON_NAME = "neuron_01"
+SPINE_MORPH_NAME = "neuron_01"
+N_SPINES = 3
+
+# Morphology (in H5v1 format)
+SAMPLE_POINTS = np.array(
+    [[0.0, 0.0, 0.0, 0.5], [1.0, 0.0, 0.0, 0.4], [2.0, 0.0, 0.0, 0.3]],
+    dtype=np.float32,
+)
+SAMPLE_STRUCTURE = np.array([[0, 3, -1]], dtype=np.int32)
+
+# Mesh primitives
+SAMPLE_VERTICES = np.array(
+    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+)
+SAMPLE_TRIANGLES = np.array([[0, 1, 2]], dtype=np.int32)
+
+# Spine skeletons (3 root sections for 3 spines)
+SKELETON_POINTS = np.array(
+    [
+        [0, 0, 0, 0.1], [0, 1, 0, 0.1], [0, 2, 0, 0.1],
+        [0, 0, 1, 0.1], [0, 1, 1, 0.1],
+        [0, 0, 2, 0.1], [0, 1, 2, 0.1],
+    ],
+    dtype=np.float32,
+)
+SKELETON_STRUCTURE = np.array(
+    [[0, 2, -1], [2, 2, -1], [4, 2, -1]], dtype=np.int32
+)
+
+# Spine meshes (3 spines, each with its own [0,1,2] triangle into local vertices)
+SPINE_MESH_VERTICES = np.tile(SAMPLE_VERTICES, (N_SPINES, 1))
+SPINE_MESH_TRIANGLES = np.array(
+    [[0, 1, 2], [0, 1, 2], [0, 1, 2]], dtype=np.int32
+)
+SPINE_MESH_OFFSETS = np.array(
+    [[0, 0], [3, 1], [6, 2], [9, 3]], dtype=np.int32
+)
+
+# Soma mesh
+SOMA_VERTICES = np.array(
+    [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32
+)
+SOMA_TRIANGLES = np.array([[0, 1, 2], [1, 2, 3]], dtype=np.int32)
+
+# Edge/spine table column data
+EDGE_TABLE_DATA = {
+    "afferent_surface_x": np.array([1.0, 2.0, 3.0]),
+    "afferent_surface_y": np.array([1.1, 2.1, 3.1]),
+    "afferent_surface_z": np.array([1.2, 2.2, 3.2]),
+    "afferent_center_x": np.array([0.5, 1.5, 2.5]),
+    "afferent_center_y": np.array([0.6, 1.6, 2.6]),
+    "afferent_center_z": np.array([0.7, 1.7, 2.7]),
+    "spine_length": np.array([1.5, 2.0, 1.8]),
+    "spine_orientation_vector_x": np.array([0.0, 0.0, 0.0]),
+    "spine_orientation_vector_y": np.array([1.0, 1.0, 1.0]),
+    "spine_orientation_vector_z": np.array([0.0, 0.0, 0.0]),
+    "spine_rotation_x": np.array([0.0, 0.0, 0.0]),
+    "spine_rotation_y": np.array([0.0, 0.0, 0.0]),
+    "spine_rotation_z": np.array([0.0, 0.0, 0.0]),
+    "spine_rotation_w": np.array([1.0, 1.0, 1.0]),
+    "afferent_section_id": np.array([0, 0, 0], dtype=np.uint32),
+    "afferent_segment_id": np.array([0, 0, 0], dtype=np.int32),
+    "afferent_segment_offset": np.array([0.1, 0.2, 0.3]),
+    "afferent_section_pos": np.array([0.1, 0.5, 0.9]),
+}
+
+
+@pytest.fixture
+def valid_spine_table():
+    """Create a minimal valid spine table DataFrame with all mandatory columns."""
+    data = {col: arr.copy() for col, arr in EDGE_TABLE_DATA.items()}
+    data["spine_morphology"] = [SPINE_MORPH_NAME] * N_SPINES
+    data["spine_id"] = np.arange(N_SPINES, dtype=np.uint32)
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def sample_vertices():
+    """Minimal 3-vertex mesh."""
+    return SAMPLE_VERTICES.copy()
+
+
+@pytest.fixture
+def sample_triangles():
+    """Single triangle referencing sample_vertices."""
+    return SAMPLE_TRIANGLES.copy()
+
+
+@pytest.fixture
+def sample_points():
+    """Minimal morphology points (3 samples, H5v1 format: x, y, z, radius)."""
+    return SAMPLE_POINTS.copy()
+
+
+@pytest.fixture
+def sample_structure():
+    """Minimal morphology structure (single root section)."""
+    return SAMPLE_STRUCTURE.copy()
+
+
+def write_minimal_valid_file(filepath):
+    """Create a minimal valid morph-with-spines HDF5 file.
+
+    Contains all four top-level groups (/morphology, /edges, /spines, /soma)
+    with consistent data for a single neuron with 3 spines.
+    """
+    # Build spine table from shared constants
+    spine_table = pd.DataFrame(
+        {col: arr.copy() for col, arr in EDGE_TABLE_DATA.items()}
+    )
+    spine_table["spine_morphology"] = [SPINE_MORPH_NAME] * N_SPINES
+    spine_table["spine_id"] = np.arange(N_SPINES, dtype=np.uint32)
+
+    # /morphology
+    with h5py.File(filepath, "w") as h5:
+        morph_grp = h5.create_group(f"{GRP_MORPH}/{NEURON_NAME}")
+        morph_grp.create_dataset("points", data=SAMPLE_POINTS)
+        morph_grp.create_dataset("structure", data=SAMPLE_STRUCTURE)
+        meta = morph_grp.create_group(GRP_METADATA)
+        meta.attrs["version"] = np.array([1, 3], dtype=np.uint32)
+
+    # /edges
+    from morph_spines.utils.morph_spine_writer import write_spine_table
+    write_spine_table(str(filepath), NEURON_NAME, spine_table)
+
+    # /spines and /soma
+    with h5py.File(filepath, "a") as h5:
+        # /spines/skeletons
+        skel_grp = h5.create_group(
+            f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
+        )
+        skel_grp.create_dataset("points", data=SKELETON_POINTS)
+        skel_grp.create_dataset("structure", data=SKELETON_STRUCTURE)
+        skel_meta = skel_grp.create_group(GRP_METADATA)
+        skel_meta.attrs["version"] = np.array([1, 3], dtype=np.uint32)
+
+        # /spines/meshes
+        mesh_grp = h5.create_group(
+            f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
+        )
+        mesh_grp.create_dataset(
+            GRP_VERTICES, data=SPINE_MESH_VERTICES, compression="gzip"
+        )
+        mesh_grp.create_dataset(
+            GRP_TRIANGLES, data=SPINE_MESH_TRIANGLES, compression="gzip"
+        )
+        mesh_grp.create_dataset(
+            GRP_OFFSETS, data=SPINE_MESH_OFFSETS, compression="gzip"
+        )
+
+        # /soma
+        soma_grp = h5.create_group(f"soma/{GRP_MESHES}/{NEURON_NAME}")
+        soma_grp.create_dataset(GRP_VERTICES, data=SOMA_VERTICES)
+        soma_grp.create_dataset(GRP_TRIANGLES, data=SOMA_TRIANGLES)
+
+
+@pytest.fixture
+def minimal_valid_file(tmp_path):
+    """Create a minimal valid morph-with-spines file and return its path."""
+    filepath = tmp_path / "valid.h5"
+    write_minimal_valid_file(filepath)
+    return filepath

--- a/tests/unit/utils/test_morph_spine_merger.py
+++ b/tests/unit/utils/test_morph_spine_merger.py
@@ -104,16 +104,15 @@ class TestValidation:
         with h5py.File(src, "w") as h5:
             h5.create_group("other")
 
-        with pytest.raises(ValueError, match="Invalid file: No /morphology group"):
+        with pytest.raises(ValueError, match="Invalid file"):
             merge_morphologies_with_spines([src], tmp_path / "out.h5")
 
     def test_missing_spines_table(self, tmp_path):
         src = tmp_path / "src.h5"
         write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
-        # Add /spines/skeletons so validation gets past that check
         write_spine_skeletons(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
 
-        with pytest.raises(ValueError, match="Invalid file: No /edges/neuron_A/spine_morphology"):
+        with pytest.raises(ValueError, match="Invalid file"):
             merge_morphologies_with_spines([src], tmp_path / "out.h5")
 
     def test_duplicate_destination_names(self, tmp_path):
@@ -379,7 +378,7 @@ class TestEdgeCases:
         write_morphology(str(src), "neuron_A", SAMPLE_POINTS, SAMPLE_STRUCTURE)
         write_spine_table(str(src), "neuron_A", _make_spine_table("neuron_A", 2))
 
-        with pytest.raises(ValueError, match="Invalid file: No /spines/skeletons group"):
+        with pytest.raises(ValueError, match="Invalid file"):
             merge_morphologies_with_spines([src], tmp_path / "out.h5", include_meshes=False)
 
     def test_missing_referenced_spine_group_raises(self, tmp_path):
@@ -389,7 +388,7 @@ class TestEdgeCases:
         write_spine_table(str(src), "neuron_A", _make_spine_table("missing_group", 2))
         write_spine_skeletons(str(src), "other_group", SAMPLE_POINTS, SAMPLE_STRUCTURE)
 
-        with pytest.raises(ValueError, match="not found in /spines/skeletons"):
+        with pytest.raises(ValueError, match="Invalid file"):
             merge_morphologies_with_spines([src], tmp_path / "out.h5")
 
     def test_referential_integrity_after_rename(self, tmp_path):

--- a/tests/unit/utils/test_morph_spine_validator.py
+++ b/tests/unit/utils/test_morph_spine_validator.py
@@ -422,6 +422,25 @@ class TestEdgesGroup:
         assert not result.is_valid
         assert any("version" in e for e in result.errors)
 
+    def test_spine_type_invalid_values(self, tmp_path):
+        """Invalid spine_type values report error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            dt = h5py.string_dtype(encoding="utf-8")
+            grp.create_dataset(
+                "spine_type",
+                data=np.array(
+                    ["thin", "invalid_type", "mushroom"],
+                    dtype=object,
+                ),
+                dtype=dt,
+            )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not result.is_valid
+        assert any("invalid_type" in e for e in result.errors)
+
 
 class TestSpinesGroup:
     """Tests for /spines group validation."""
@@ -833,6 +852,23 @@ class TestCrossGroupIntegrity:
             )
         result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert any("spine_morphology" in w and "meshes" in w for w in result.warnings)
+
+    def test_afferent_section_id_exceeds_morphology(self, tmp_path):
+        """afferent_section_id exceeding section count errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            # Morphology has 1 section (structure has 1 row)
+            # Set afferent_section_id to 5 which is out of bounds
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_section_id"]
+            grp.create_dataset(
+                "afferent_section_id",
+                data=np.array([0, 0, 5], dtype=np.uint32),
+            )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not result.is_valid
+        assert any("afferent_section_id" in e for e in result.errors)
 
 
 class TestValidationResult:

--- a/tests/unit/utils/test_morph_spine_validator.py
+++ b/tests/unit/utils/test_morph_spine_validator.py
@@ -14,7 +14,6 @@ from morph_spines.core.h5_schema import (
     GRP_SPINES,
     GRP_TRIANGLES,
     GRP_VERTICES,
-    SPINE_TABLE_VER_H5_DATASETS,
 )
 from morph_spines.utils.morph_spine_validator import (
     ValidationResult,
@@ -57,9 +56,7 @@ class TestFileLevelChecks:
         """Valid file passes with data integrity checks enabled."""
         filepath = tmp_path / "valid.h5"
         write_minimal_valid_file(filepath)
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert result.is_valid
         assert result.data_integrity_checked
 
@@ -77,9 +74,7 @@ class TestFileLevelChecks:
             h5.create_group("unexpected_group")
         result = validate_morph_with_spines_file(filepath)
         assert result.is_valid
-        assert any(
-            "unexpected_group" in w for w in result.warnings
-        )
+        assert any("unexpected_group" in w for w in result.warnings)
 
 
 class TestMorphologyGroup:
@@ -116,9 +111,7 @@ class TestMorphologyGroup:
                 "points",
                 data=np.ones((3, 3), dtype=np.float32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape (N, 4)" in e for e in result.errors)
 
@@ -133,9 +126,7 @@ class TestMorphologyGroup:
                 "points",
                 data=np.ones((3, 4), dtype=np.float64),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert result.is_valid
         assert any("float32" in w for w in result.warnings)
 
@@ -149,9 +140,7 @@ class TestMorphologyGroup:
             data = np.ones((3, 4), dtype=np.float32)
             data[1, 2] = np.nan
             grp.create_dataset("points", data=data)
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("NaN" in e for e in result.errors)
 
@@ -176,9 +165,7 @@ class TestMorphologyGroup:
                 "structure",
                 data=np.ones((3, 2), dtype=np.int32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape (M, 3)" in e for e in result.errors)
 
@@ -192,9 +179,7 @@ class TestMorphologyGroup:
             data = np.ones((3, 4), dtype=np.float32)
             data[0, 0] = np.inf
             grp.create_dataset("points", data=data)
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("Inf" in e for e in result.errors)
 
@@ -209,9 +194,7 @@ class TestMorphologyGroup:
                 "points",
                 data=np.empty((0, 4), dtype=np.float32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("empty" in e for e in result.errors)
 
@@ -226,23 +209,17 @@ class TestMorphologyGroup:
                 "structure",
                 data=np.empty((0, 3), dtype=np.int32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("empty" in e for e in result.errors)
 
-    def test_morphology_entry_is_dataset_not_group(
-        self, tmp_path
-    ):
+    def test_morphology_entry_is_dataset_not_group(self, tmp_path):
         """A dataset instead of group under /morphology errors."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_MORPH}/{NEURON_NAME}"]
-            h5[GRP_MORPH].create_dataset(
-                NEURON_NAME, data=np.zeros(3)
-            )
+            h5[GRP_MORPH].create_dataset(NEURON_NAME, data=np.zeros(3))
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("not a group" in e for e in result.errors)
@@ -277,9 +254,7 @@ class TestEdgesGroup:
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            grp.create_dataset(
-                "unknown_col", data=np.zeros(3)
-            )
+            grp.create_dataset("unknown_col", data=np.zeros(3))
         result = validate_morph_with_spines_file(filepath)
         assert result.is_valid
         assert any("unknown_col" in w for w in result.warnings)
@@ -289,12 +264,8 @@ class TestEdgesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            meta = h5[
-                f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"
-            ]
-            meta.attrs[ATT_VERSION] = np.array(
-                [99, 0], dtype=np.uint32
-            )
+            meta = h5[f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"]
+            meta.attrs[ATT_VERSION] = np.array([99, 0], dtype=np.uint32)
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("version" in e for e in result.errors)
@@ -308,13 +279,9 @@ class TestEdgesGroup:
             del grp["afferent_section_pos"]
             grp.create_dataset(
                 "afferent_section_pos",
-                data=np.array(
-                    [0.5, 1.5, -0.1], dtype=np.float64
-                ),
+                data=np.array([0.5, 1.5, -0.1], dtype=np.float64),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("outside" in e for e in result.errors)
 
@@ -327,13 +294,9 @@ class TestEdgesGroup:
             del grp["spine_length"]
             grp.create_dataset(
                 "spine_length",
-                data=np.array(
-                    [1.0, 0.0, -0.5], dtype=np.float64
-                ),
+                data=np.array([1.0, 0.0, -0.5], dtype=np.float64),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("<= 0" in e for e in result.errors)
 
@@ -346,19 +309,13 @@ class TestEdgesGroup:
             del grp["afferent_segment_offset"]
             grp.create_dataset(
                 "afferent_segment_offset",
-                data=np.array(
-                    [0.1, -0.5, 0.3], dtype=np.float64
-                ),
+                data=np.array([0.1, -0.5, 0.3], dtype=np.float64),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("negative" in e for e in result.errors)
 
-    def test_spine_morphology_invalid_reference(
-        self, tmp_path
-    ):
+    def test_spine_morphology_invalid_reference(self, tmp_path):
         """spine_morphology referencing nonexistent group."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
@@ -368,19 +325,12 @@ class TestEdgesGroup:
             dt = h5py.string_dtype(encoding="utf-8")
             grp.create_dataset(
                 "spine_morphology",
-                data=np.array(
-                    ["nonexistent_group"] * 3, dtype=object
-                ),
+                data=np.array(["nonexistent_group"] * 3, dtype=object),
                 dtype=dt,
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "nonexistent_group" in e or "not in" in e
-            for e in result.errors
-        )
+        assert any("nonexistent_group" in e or "not in" in e for e in result.errors)
 
     def test_empty_edges_group(self, tmp_path):
         """Empty /edges group reports error."""
@@ -403,14 +353,9 @@ class TestEdgesGroup:
                 "spine_length",
                 data=np.array([1.0, 2.0], dtype=np.float64),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "inconsistent lengths" in e
-            for e in result.errors
-        )
+        assert any("inconsistent lengths" in e for e in result.errors)
 
     def test_nan_in_float_column(self, tmp_path):
         """NaN in float column reports error."""
@@ -419,15 +364,9 @@ class TestEdgesGroup:
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["afferent_surface_x"]
-            data = np.array(
-                [1.0, np.nan, 3.0], dtype=np.float64
-            )
-            grp.create_dataset(
-                "afferent_surface_x", data=data
-            )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+            data = np.array([1.0, np.nan, 3.0], dtype=np.float64)
+            grp.create_dataset("afferent_surface_x", data=data)
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("NaN" in e for e in result.errors)
 
@@ -438,15 +377,9 @@ class TestEdgesGroup:
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["afferent_surface_y"]
-            data = np.array(
-                [1.0, np.inf, 3.0], dtype=np.float64
-            )
-            grp.create_dataset(
-                "afferent_surface_y", data=data
-            )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+            data = np.array([1.0, np.inf, 3.0], dtype=np.float64)
+            grp.create_dataset("afferent_surface_y", data=data)
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("Inf" in e for e in result.errors)
 
@@ -460,42 +393,30 @@ class TestEdgesGroup:
             dt = h5py.string_dtype(encoding="utf-8")
             grp.create_dataset(
                 "afferent_section_id",
-                data=np.array(
-                    ["a", "b", "c"], dtype=object
-                ),
+                data=np.array(["a", "b", "c"], dtype=object),
                 dtype=dt,
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("integer" in e for e in result.errors)
 
-    def test_edges_entry_is_dataset_not_group(
-        self, tmp_path
-    ):
+    def test_edges_entry_is_dataset_not_group(self, tmp_path):
         """A dataset instead of group under /edges errors."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            h5[GRP_EDGES].create_dataset(
-                NEURON_NAME, data=np.zeros(3)
-            )
+            h5[GRP_EDGES].create_dataset(NEURON_NAME, data=np.zeros(3))
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("not a group" in e for e in result.errors)
 
-    def test_edges_metadata_missing_version_attr(
-        self, tmp_path
-    ):
+    def test_edges_metadata_missing_version_attr(self, tmp_path):
         """Metadata group without version attribute errors."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            meta = h5[
-                f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"
-            ]
+            meta = h5[f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"]
             del meta.attrs[ATT_VERSION]
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
@@ -540,19 +461,14 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            skel_path = (
-                f"{GRP_SPINES}/{GRP_SKELETONS}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            skel_path = f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
             grp = h5[skel_path]
             del grp["points"]
             grp.create_dataset(
                 "points",
                 data=np.ones((5, 3), dtype=np.float32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape (N, 4)" in e for e in result.errors)
 
@@ -561,10 +477,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             del h5[f"{mesh_path}/{GRP_OFFSETS}"]
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
@@ -575,20 +488,13 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_VERTICES]
             data = np.ones((9, 3), dtype=np.float32)
             data[2, 1] = np.nan
-            grp.create_dataset(
-                GRP_VERTICES, data=data, compression="gzip"
-            )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+            grp.create_dataset(GRP_VERTICES, data=data, compression="gzip")
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("NaN" in e for e in result.errors)
 
@@ -597,10 +503,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_VERTICES]
             grp.create_dataset(
@@ -608,9 +511,7 @@ class TestSpinesGroup:
                 data=np.ones((9, 2), dtype=np.float32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape (N, 3)" in e for e in result.errors)
 
@@ -619,10 +520,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_TRIANGLES]
             grp.create_dataset(
@@ -630,9 +528,7 @@ class TestSpinesGroup:
                 data=np.ones((3, 4), dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape (M, 3)" in e for e in result.errors)
 
@@ -641,10 +537,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_TRIANGLES]
             # Each spine has 3 local vertices; index 5 is OOB
@@ -656,23 +549,16 @@ class TestSpinesGroup:
                 ),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "local vertex count" in e for e in result.errors
-        )
+        assert any("local vertex count" in e for e in result.errors)
 
     def test_offsets_wrong_shape(self, tmp_path):
         """Offsets with shape (4,4) reports shape error."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_OFFSETS]
             grp.create_dataset(
@@ -680,9 +566,7 @@ class TestSpinesGroup:
                 data=np.ones((4, 4), dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("shape" in e for e in result.errors)
 
@@ -691,10 +575,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_OFFSETS]
             # Non-decreasing violation: 6 -> 3
@@ -706,23 +587,16 @@ class TestSpinesGroup:
                 ),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "non-decreasing" in e for e in result.errors
-        )
+        assert any("non-decreasing" in e for e in result.errors)
 
     def test_offsets_first_row_not_zero(self, tmp_path):
         """Offsets with non-zero first row produces warning."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_OFFSETS]
             # First row not zero
@@ -744,47 +618,33 @@ class TestSpinesGroup:
             del grp[GRP_TRIANGLES]
             grp.create_dataset(
                 GRP_TRIANGLES,
-                data=np.array(
-                    [[0, 1, 2]] * 4, dtype=np.int32
-                ),
+                data=np.array([[0, 1, 2]] * 4, dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert result.is_valid
         assert any("first row" in w for w in result.warnings)
 
-    def test_skeleton_entry_is_dataset_not_group(
-        self, tmp_path
-    ):
+    def test_skeleton_entry_is_dataset_not_group(self, tmp_path):
         """A dataset instead of group under skeletons errors."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            skel_parent = h5[
-                f"{GRP_SPINES}/{GRP_SKELETONS}"
-            ]
+            skel_parent = h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
             del skel_parent[SPINE_MORPH_NAME]
-            skel_parent.create_dataset(
-                SPINE_MORPH_NAME, data=np.zeros(3)
-            )
+            skel_parent.create_dataset(SPINE_MORPH_NAME, data=np.zeros(3))
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("not a group" in e for e in result.errors)
 
-    def test_mesh_entry_is_dataset_not_group(
-        self, tmp_path
-    ):
+    def test_mesh_entry_is_dataset_not_group(self, tmp_path):
         """A dataset instead of group under meshes errors."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
             mesh_parent = h5[f"{GRP_SPINES}/{GRP_MESHES}"]
             del mesh_parent[SPINE_MORPH_NAME]
-            mesh_parent.create_dataset(
-                SPINE_MORPH_NAME, data=np.zeros(3)
-            )
+            mesh_parent.create_dataset(SPINE_MORPH_NAME, data=np.zeros(3))
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("not a group" in e for e in result.errors)
@@ -794,20 +654,13 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_VERTICES]
             data = np.ones((9, 3), dtype=np.float32)
             data[0, 0] = np.inf
-            grp.create_dataset(
-                GRP_VERTICES, data=data, compression="gzip"
-            )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+            grp.create_dataset(GRP_VERTICES, data=data, compression="gzip")
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
         assert any("Inf" in e for e in result.errors)
 
@@ -816,10 +669,7 @@ class TestSpinesGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_OFFSETS]
             grp.create_dataset(
@@ -827,23 +677,16 @@ class TestSpinesGroup:
                 data=np.array([[0, 0]], dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "at least 2 rows" in e for e in result.errors
-        )
+        assert any("at least 2 rows" in e for e in result.errors)
 
     def test_triangle_offsets_non_decreasing(self, tmp_path):
         """Triangle offsets going backwards reports error."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             grp = h5[mesh_path]
             del grp[GRP_OFFSETS]
             # Triangle offsets (col 1) go backwards
@@ -855,13 +698,9 @@ class TestSpinesGroup:
                 ),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "non-decreasing" in e for e in result.errors
-        )
+        assert any("non-decreasing" in e for e in result.errors)
 
 
 class TestSomaGroup:
@@ -875,20 +714,14 @@ class TestSomaGroup:
             del h5["soma"]
         result = validate_morph_with_spines_file(filepath)
         assert result.is_valid
-        assert any(
-            "soma" in i and "not present" in i
-            for i in result.info
-        )
+        assert any("soma" in i and "not present" in i for i in result.info)
 
     def test_soma_missing_vertices(self, tmp_path):
         """Missing vertices in soma mesh reports error."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            del h5[
-                f"soma/{GRP_MESHES}/{NEURON_NAME}"
-                f"/{GRP_VERTICES}"
-            ]
+            del h5[f"soma/{GRP_MESHES}/{NEURON_NAME}/{GRP_VERTICES}"]
         result = validate_morph_with_spines_file(filepath)
         assert not result.is_valid
         assert any("vertices" in e for e in result.errors)
@@ -898,48 +731,30 @@ class TestSomaGroup:
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            soma_path = (
-                f"soma/{GRP_MESHES}/{NEURON_NAME}"
-            )
+            soma_path = f"soma/{GRP_MESHES}/{NEURON_NAME}"
             del h5[f"{soma_path}/{GRP_VERTICES}"]
             h5[soma_path].create_dataset(
                 GRP_VERTICES,
                 data=np.ones((4, 2), dtype=np.float32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "soma" in e
-            and "vertices" in e
-            and "shape (N, 3)" in e
-            for e in result.errors
-        )
+        assert any("soma" in e and "vertices" in e and "shape (N, 3)" in e for e in result.errors)
 
     def test_soma_triangles_wrong_shape(self, tmp_path):
         """Soma triangles with shape (2,4) reports error."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            soma_path = (
-                f"soma/{GRP_MESHES}/{NEURON_NAME}"
-            )
+            soma_path = f"soma/{GRP_MESHES}/{NEURON_NAME}"
             del h5[f"{soma_path}/{GRP_TRIANGLES}"]
             h5[soma_path].create_dataset(
                 GRP_TRIANGLES,
                 data=np.ones((2, 4), dtype=np.int32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "soma" in e
-            and "triangles" in e
-            and "shape (M, 3)" in e
-            for e in result.errors
-        )
+        assert any("soma" in e and "triangles" in e and "shape (M, 3)" in e for e in result.errors)
 
 
 class TestCrossGroupIntegrity:
@@ -954,17 +769,11 @@ class TestCrossGroupIntegrity:
                 f"{GRP_MORPH}/{NEURON_NAME}",
                 f"{GRP_MORPH}/other_neuron",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "not in /morphology" in e for e in result.errors
-        )
+        assert any("not in /morphology" in e for e in result.errors)
 
-    def test_spine_id_exceeds_skeleton_root_sections(
-        self, tmp_path
-    ):
+    def test_spine_id_exceeds_skeleton_root_sections(self, tmp_path):
         """spine_id exceeding root sections reports error."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
@@ -975,14 +784,9 @@ class TestCrossGroupIntegrity:
                 "spine_id",
                 data=np.array([0, 1, 99], dtype=np.uint32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "spine_id=99" in e and "skeleton" in e
-            for e in result.errors
-        )
+        assert any("spine_id=99" in e and "skeleton" in e for e in result.errors)
 
     def test_spine_id_exceeds_mesh_offsets(self, tmp_path):
         """spine_id exceeding mesh offset count errors."""
@@ -990,10 +794,7 @@ class TestCrossGroupIntegrity:
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
             # Add more root sections to skeleton (5 roots)
-            skel_path = (
-                f"{GRP_SPINES}/{GRP_SKELETONS}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            skel_path = f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
             skel_grp = h5[skel_path]
             del skel_grp["structure"]
             skel_grp.create_dataset(
@@ -1016,37 +817,22 @@ class TestCrossGroupIntegrity:
                 "spine_id",
                 data=np.array([0, 1, 4], dtype=np.uint32),
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not result.is_valid
-        assert any(
-            "spine_id=4" in e and "mesh" in e
-            for e in result.errors
-        )
+        assert any("spine_id=4" in e and "mesh" in e for e in result.errors)
 
-    def test_spine_morphology_missing_mesh_warning(
-        self, tmp_path
-    ):
+    def test_spine_morphology_missing_mesh_warning(self, tmp_path):
         """spine_morphology referencing missing mesh warns."""
         filepath = tmp_path / "test.h5"
         write_minimal_valid_file(filepath)
         with h5py.File(filepath, "a") as h5:
-            mesh_path = (
-                f"{GRP_SPINES}/{GRP_MESHES}"
-                f"/{SPINE_MORPH_NAME}"
-            )
+            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
             h5.move(
                 mesh_path,
                 f"{GRP_SPINES}/{GRP_MESHES}/other_name",
             )
-        result = validate_morph_with_spines_file(
-            filepath, check_data_integrity=True
-        )
-        assert any(
-            "spine_morphology" in w and "meshes" in w
-            for w in result.warnings
-        )
+        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert any("spine_morphology" in w and "meshes" in w for w in result.warnings)
 
 
 class TestValidationResult:

--- a/tests/unit/utils/test_morph_spine_validator.py
+++ b/tests/unit/utils/test_morph_spine_validator.py
@@ -1,0 +1,1114 @@
+"""Unit tests for morph_spines.utils.morph_spine_validator."""
+
+import h5py
+import numpy as np
+
+from morph_spines.core.h5_schema import (
+    ATT_VERSION,
+    GRP_EDGES,
+    GRP_MESHES,
+    GRP_METADATA,
+    GRP_MORPH,
+    GRP_OFFSETS,
+    GRP_SKELETONS,
+    GRP_SPINES,
+    GRP_TRIANGLES,
+    GRP_VERTICES,
+    SPINE_TABLE_VER_H5_DATASETS,
+)
+from morph_spines.utils.morph_spine_validator import (
+    ValidationResult,
+    validate_morph_with_spines_file,
+)
+from tests.conftest import (
+    NEURON_NAME,
+    SPINE_MORPH_NAME,
+    write_minimal_valid_file,
+)
+
+
+class TestFileLevelChecks:
+    """Tests for basic file-level validation checks."""
+
+    def test_file_not_found(self, tmp_path):
+        """Nonexistent file produces 'not found' error."""
+        path = tmp_path / "nonexistent.h5"
+        result = validate_morph_with_spines_file(path)
+        assert not result.is_valid
+        assert any("not found" in e for e in result.errors)
+
+    def test_not_hdf5(self, tmp_path):
+        """Plain text file produces 'Cannot open' error."""
+        path = tmp_path / "bad.h5"
+        path.write_text("not an hdf5 file")
+        result = validate_morph_with_spines_file(path)
+        assert not result.is_valid
+        assert any("Cannot open" in e for e in result.errors)
+
+    def test_valid_file_structure_only(self, tmp_path):
+        """Valid file passes structural validation."""
+        filepath = tmp_path / "valid.h5"
+        write_minimal_valid_file(filepath)
+        result = validate_morph_with_spines_file(filepath)
+        assert result.is_valid
+        assert not result.data_integrity_checked
+
+    def test_valid_file_with_data_integrity(self, tmp_path):
+        """Valid file passes with data integrity checks enabled."""
+        filepath = tmp_path / "valid.h5"
+        write_minimal_valid_file(filepath)
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert result.is_valid
+        assert result.data_integrity_checked
+
+    def test_path_is_directory(self, tmp_path):
+        """Validating a directory path reports error."""
+        result = validate_morph_with_spines_file(tmp_path)
+        assert not result.is_valid
+        assert any("not a file" in e for e in result.errors)
+
+    def test_unexpected_top_level_groups(self, tmp_path):
+        """Unexpected top-level groups produce warning."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            h5.create_group("unexpected_group")
+        result = validate_morph_with_spines_file(filepath)
+        assert result.is_valid
+        assert any(
+            "unexpected_group" in w for w in result.warnings
+        )
+
+
+class TestMorphologyGroup:
+    """Tests for /morphology group validation."""
+
+    def test_missing_morphology_group(self, tmp_path):
+        """File without /morphology reports error."""
+        filepath = tmp_path / "no_morph.h5"
+        with h5py.File(filepath, "w") as h5:
+            h5.create_group(GRP_EDGES)
+            h5.create_group(GRP_SPINES)
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("/morphology" in e for e in result.errors)
+
+    def test_missing_points_dataset(self, tmp_path):
+        """Missing points dataset in morphology reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_MORPH}/{NEURON_NAME}/points"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("missing 'points'" in e for e in result.errors)
+
+    def test_wrong_points_shape(self, tmp_path):
+        """Points with wrong shape (3,3) reports shape error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["points"]
+            grp.create_dataset(
+                "points",
+                data=np.ones((3, 3), dtype=np.float32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape (N, 4)" in e for e in result.errors)
+
+    def test_points_not_float32_warning(self, tmp_path):
+        """Points with float64 dtype produces warning."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["points"]
+            grp.create_dataset(
+                "points",
+                data=np.ones((3, 4), dtype=np.float64),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert result.is_valid
+        assert any("float32" in w for w in result.warnings)
+
+    def test_points_with_nan(self, tmp_path):
+        """Points containing NaN values reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["points"]
+            data = np.ones((3, 4), dtype=np.float32)
+            data[1, 2] = np.nan
+            grp.create_dataset("points", data=data)
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("NaN" in e for e in result.errors)
+
+    def test_empty_morphology_group(self, tmp_path):
+        """Empty /morphology group reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("empty" in e for e in result.errors)
+
+    def test_structure_wrong_shape(self, tmp_path):
+        """Structure with shape (3,2) reports shape error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["structure"]
+            grp.create_dataset(
+                "structure",
+                data=np.ones((3, 2), dtype=np.int32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape (M, 3)" in e for e in result.errors)
+
+    def test_points_with_inf(self, tmp_path):
+        """Points containing Inf values reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["points"]
+            data = np.ones((3, 4), dtype=np.float32)
+            data[0, 0] = np.inf
+            grp.create_dataset("points", data=data)
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("Inf" in e for e in result.errors)
+
+    def test_empty_points(self, tmp_path):
+        """Empty points dataset reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["points"]
+            grp.create_dataset(
+                "points",
+                data=np.empty((0, 4), dtype=np.float32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("empty" in e for e in result.errors)
+
+    def test_empty_structure(self, tmp_path):
+        """Empty structure dataset reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp["structure"]
+            grp.create_dataset(
+                "structure",
+                data=np.empty((0, 3), dtype=np.int32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("empty" in e for e in result.errors)
+
+    def test_morphology_entry_is_dataset_not_group(
+        self, tmp_path
+    ):
+        """A dataset instead of group under /morphology errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            h5[GRP_MORPH].create_dataset(
+                NEURON_NAME, data=np.zeros(3)
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("not a group" in e for e in result.errors)
+
+
+class TestEdgesGroup:
+    """Tests for /edges group validation."""
+
+    def test_missing_edges_group(self, tmp_path):
+        """File without /edges reports error."""
+        filepath = tmp_path / "no_edges.h5"
+        with h5py.File(filepath, "w") as h5:
+            h5.create_group(GRP_MORPH)
+            h5.create_group(GRP_SPINES)
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("/edges" in e for e in result.errors)
+
+    def test_missing_mandatory_column(self, tmp_path):
+        """Missing spine_length column reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_EDGES}/{NEURON_NAME}/spine_length"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("spine_length" in e for e in result.errors)
+
+    def test_unknown_column_warning(self, tmp_path):
+        """Unknown column dataset produces warning."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            grp.create_dataset(
+                "unknown_col", data=np.zeros(3)
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert result.is_valid
+        assert any("unknown_col" in w for w in result.warnings)
+
+    def test_wrong_metadata_version(self, tmp_path):
+        """Wrong spine table version reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            meta = h5[
+                f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"
+            ]
+            meta.attrs[ATT_VERSION] = np.array(
+                [99, 0], dtype=np.uint32
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("version" in e for e in result.errors)
+
+    def test_afferent_section_pos_out_of_range(self, tmp_path):
+        """Section pos values outside [0,1] report error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_section_pos"]
+            grp.create_dataset(
+                "afferent_section_pos",
+                data=np.array(
+                    [0.5, 1.5, -0.1], dtype=np.float64
+                ),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("outside" in e for e in result.errors)
+
+    def test_spine_length_zero(self, tmp_path):
+        """Spine length with zero or negative values errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["spine_length"]
+            grp.create_dataset(
+                "spine_length",
+                data=np.array(
+                    [1.0, 0.0, -0.5], dtype=np.float64
+                ),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("<= 0" in e for e in result.errors)
+
+    def test_afferent_segment_offset_negative(self, tmp_path):
+        """Negative segment offset values report error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_segment_offset"]
+            grp.create_dataset(
+                "afferent_segment_offset",
+                data=np.array(
+                    [0.1, -0.5, 0.3], dtype=np.float64
+                ),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("negative" in e for e in result.errors)
+
+    def test_spine_morphology_invalid_reference(
+        self, tmp_path
+    ):
+        """spine_morphology referencing nonexistent group."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["spine_morphology"]
+            dt = h5py.string_dtype(encoding="utf-8")
+            grp.create_dataset(
+                "spine_morphology",
+                data=np.array(
+                    ["nonexistent_group"] * 3, dtype=object
+                ),
+                dtype=dt,
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "nonexistent_group" in e or "not in" in e
+            for e in result.errors
+        )
+
+    def test_empty_edges_group(self, tmp_path):
+        """Empty /edges group reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("empty" in e for e in result.errors)
+
+    def test_inconsistent_dataset_lengths(self, tmp_path):
+        """Datasets with different lengths report error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["spine_length"]
+            grp.create_dataset(
+                "spine_length",
+                data=np.array([1.0, 2.0], dtype=np.float64),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "inconsistent lengths" in e
+            for e in result.errors
+        )
+
+    def test_nan_in_float_column(self, tmp_path):
+        """NaN in float column reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_surface_x"]
+            data = np.array(
+                [1.0, np.nan, 3.0], dtype=np.float64
+            )
+            grp.create_dataset(
+                "afferent_surface_x", data=data
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("NaN" in e for e in result.errors)
+
+    def test_inf_in_float_column(self, tmp_path):
+        """Inf in float column reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_surface_y"]
+            data = np.array(
+                [1.0, np.inf, 3.0], dtype=np.float64
+            )
+            grp.create_dataset(
+                "afferent_surface_y", data=data
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("Inf" in e for e in result.errors)
+
+    def test_wrong_dtype_for_integer_column(self, tmp_path):
+        """String dtype for integer column reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["afferent_section_id"]
+            dt = h5py.string_dtype(encoding="utf-8")
+            grp.create_dataset(
+                "afferent_section_id",
+                data=np.array(
+                    ["a", "b", "c"], dtype=object
+                ),
+                dtype=dt,
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("integer" in e for e in result.errors)
+
+    def test_edges_entry_is_dataset_not_group(
+        self, tmp_path
+    ):
+        """A dataset instead of group under /edges errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            h5[GRP_EDGES].create_dataset(
+                NEURON_NAME, data=np.zeros(3)
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("not a group" in e for e in result.errors)
+
+    def test_edges_metadata_missing_version_attr(
+        self, tmp_path
+    ):
+        """Metadata group without version attribute errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            meta = h5[
+                f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"
+            ]
+            del meta.attrs[ATT_VERSION]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("version" in e for e in result.errors)
+
+
+class TestSpinesGroup:
+    """Tests for /spines group validation."""
+
+    def test_missing_spines_group(self, tmp_path):
+        """File without /spines reports error."""
+        filepath = tmp_path / "no_spines.h5"
+        with h5py.File(filepath, "w") as h5:
+            h5.create_group(GRP_MORPH)
+            h5.create_group(GRP_EDGES)
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("/spines" in e for e in result.errors)
+
+    def test_missing_skeletons_subgroup(self, tmp_path):
+        """Missing /spines/skeletons reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("skeletons" in e for e in result.errors)
+
+    def test_meshes_optional(self, tmp_path):
+        """Missing /spines/meshes is valid with info message."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[f"{GRP_SPINES}/{GRP_MESHES}"]
+        result = validate_morph_with_spines_file(filepath)
+        assert result.is_valid
+        assert any("not present" in i for i in result.info)
+
+    def test_skeleton_wrong_points_shape(self, tmp_path):
+        """Skeleton points with shape (5,3) reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            skel_path = (
+                f"{GRP_SPINES}/{GRP_SKELETONS}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[skel_path]
+            del grp["points"]
+            grp.create_dataset(
+                "points",
+                data=np.ones((5, 3), dtype=np.float32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape (N, 4)" in e for e in result.errors)
+
+    def test_mesh_missing_offsets(self, tmp_path):
+        """Missing offsets dataset in mesh reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            del h5[f"{mesh_path}/{GRP_OFFSETS}"]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("offsets" in e for e in result.errors)
+
+    def test_mesh_vertices_nan(self, tmp_path):
+        """NaN in mesh vertices reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_VERTICES]
+            data = np.ones((9, 3), dtype=np.float32)
+            data[2, 1] = np.nan
+            grp.create_dataset(
+                GRP_VERTICES, data=data, compression="gzip"
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("NaN" in e for e in result.errors)
+
+    def test_mesh_vertices_wrong_shape(self, tmp_path):
+        """Mesh vertices with shape (9,2) reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_VERTICES]
+            grp.create_dataset(
+                GRP_VERTICES,
+                data=np.ones((9, 2), dtype=np.float32),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape (N, 3)" in e for e in result.errors)
+
+    def test_mesh_triangles_wrong_shape(self, tmp_path):
+        """Mesh triangles with shape (3,4) reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_TRIANGLES]
+            grp.create_dataset(
+                GRP_TRIANGLES,
+                data=np.ones((3, 4), dtype=np.int32),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape (M, 3)" in e for e in result.errors)
+
+    def test_triangle_index_out_of_bounds(self, tmp_path):
+        """Triangle index exceeding local vertex count."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_TRIANGLES]
+            # Each spine has 3 local vertices; index 5 is OOB
+            grp.create_dataset(
+                GRP_TRIANGLES,
+                data=np.array(
+                    [[0, 1, 5], [0, 1, 2], [0, 1, 2]],
+                    dtype=np.int32,
+                ),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "local vertex count" in e for e in result.errors
+        )
+
+    def test_offsets_wrong_shape(self, tmp_path):
+        """Offsets with shape (4,4) reports shape error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_OFFSETS]
+            grp.create_dataset(
+                GRP_OFFSETS,
+                data=np.ones((4, 4), dtype=np.int32),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("shape" in e for e in result.errors)
+
+    def test_offsets_non_decreasing(self, tmp_path):
+        """Offsets going backwards reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_OFFSETS]
+            # Non-decreasing violation: 6 -> 3
+            grp.create_dataset(
+                GRP_OFFSETS,
+                data=np.array(
+                    [[0, 0], [3, 1], [6, 2], [3, 3]],
+                    dtype=np.int32,
+                ),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "non-decreasing" in e for e in result.errors
+        )
+
+    def test_offsets_first_row_not_zero(self, tmp_path):
+        """Offsets with non-zero first row produces warning."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_OFFSETS]
+            # First row not zero
+            grp.create_dataset(
+                GRP_OFFSETS,
+                data=np.array(
+                    [[1, 1], [4, 2], [7, 3], [10, 4]],
+                    dtype=np.int32,
+                ),
+                compression="gzip",
+            )
+            # Also need extra vertices/triangles to match
+            del grp[GRP_VERTICES]
+            grp.create_dataset(
+                GRP_VERTICES,
+                data=np.zeros((10, 3), dtype=np.float32),
+                compression="gzip",
+            )
+            del grp[GRP_TRIANGLES]
+            grp.create_dataset(
+                GRP_TRIANGLES,
+                data=np.array(
+                    [[0, 1, 2]] * 4, dtype=np.int32
+                ),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert result.is_valid
+        assert any("first row" in w for w in result.warnings)
+
+    def test_skeleton_entry_is_dataset_not_group(
+        self, tmp_path
+    ):
+        """A dataset instead of group under skeletons errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            skel_parent = h5[
+                f"{GRP_SPINES}/{GRP_SKELETONS}"
+            ]
+            del skel_parent[SPINE_MORPH_NAME]
+            skel_parent.create_dataset(
+                SPINE_MORPH_NAME, data=np.zeros(3)
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("not a group" in e for e in result.errors)
+
+    def test_mesh_entry_is_dataset_not_group(
+        self, tmp_path
+    ):
+        """A dataset instead of group under meshes errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_parent = h5[f"{GRP_SPINES}/{GRP_MESHES}"]
+            del mesh_parent[SPINE_MORPH_NAME]
+            mesh_parent.create_dataset(
+                SPINE_MORPH_NAME, data=np.zeros(3)
+            )
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("not a group" in e for e in result.errors)
+
+    def test_vertices_with_inf(self, tmp_path):
+        """Mesh vertices with Inf reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_VERTICES]
+            data = np.ones((9, 3), dtype=np.float32)
+            data[0, 0] = np.inf
+            grp.create_dataset(
+                GRP_VERTICES, data=data, compression="gzip"
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any("Inf" in e for e in result.errors)
+
+    def test_offsets_single_row(self, tmp_path):
+        """Offsets with only 1 row reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_OFFSETS]
+            grp.create_dataset(
+                GRP_OFFSETS,
+                data=np.array([[0, 0]], dtype=np.int32),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "at least 2 rows" in e for e in result.errors
+        )
+
+    def test_triangle_offsets_non_decreasing(self, tmp_path):
+        """Triangle offsets going backwards reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            grp = h5[mesh_path]
+            del grp[GRP_OFFSETS]
+            # Triangle offsets (col 1) go backwards
+            grp.create_dataset(
+                GRP_OFFSETS,
+                data=np.array(
+                    [[0, 0], [3, 2], [6, 1], [9, 3]],
+                    dtype=np.int32,
+                ),
+                compression="gzip",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "non-decreasing" in e for e in result.errors
+        )
+
+
+class TestSomaGroup:
+    """Tests for /soma group validation."""
+
+    def test_soma_optional(self, tmp_path):
+        """Missing /soma is valid with info message."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5["soma"]
+        result = validate_morph_with_spines_file(filepath)
+        assert result.is_valid
+        assert any(
+            "soma" in i and "not present" in i
+            for i in result.info
+        )
+
+    def test_soma_missing_vertices(self, tmp_path):
+        """Missing vertices in soma mesh reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            del h5[
+                f"soma/{GRP_MESHES}/{NEURON_NAME}"
+                f"/{GRP_VERTICES}"
+            ]
+        result = validate_morph_with_spines_file(filepath)
+        assert not result.is_valid
+        assert any("vertices" in e for e in result.errors)
+
+    def test_soma_vertices_wrong_shape(self, tmp_path):
+        """Soma vertices with shape (4,2) reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            soma_path = (
+                f"soma/{GRP_MESHES}/{NEURON_NAME}"
+            )
+            del h5[f"{soma_path}/{GRP_VERTICES}"]
+            h5[soma_path].create_dataset(
+                GRP_VERTICES,
+                data=np.ones((4, 2), dtype=np.float32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "soma" in e
+            and "vertices" in e
+            and "shape (N, 3)" in e
+            for e in result.errors
+        )
+
+    def test_soma_triangles_wrong_shape(self, tmp_path):
+        """Soma triangles with shape (2,4) reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            soma_path = (
+                f"soma/{GRP_MESHES}/{NEURON_NAME}"
+            )
+            del h5[f"{soma_path}/{GRP_TRIANGLES}"]
+            h5[soma_path].create_dataset(
+                GRP_TRIANGLES,
+                data=np.ones((2, 4), dtype=np.int32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "soma" in e
+            and "triangles" in e
+            and "shape (M, 3)" in e
+            for e in result.errors
+        )
+
+
+class TestCrossGroupIntegrity:
+    """Tests for cross-group referential integrity."""
+
+    def test_edges_neuron_not_in_morphology(self, tmp_path):
+        """Edges neuron not in /morphology reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            h5.move(
+                f"{GRP_MORPH}/{NEURON_NAME}",
+                f"{GRP_MORPH}/other_neuron",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "not in /morphology" in e for e in result.errors
+        )
+
+    def test_spine_id_exceeds_skeleton_root_sections(
+        self, tmp_path
+    ):
+        """spine_id exceeding root sections reports error."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["spine_id"]
+            grp.create_dataset(
+                "spine_id",
+                data=np.array([0, 1, 99], dtype=np.uint32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "spine_id=99" in e and "skeleton" in e
+            for e in result.errors
+        )
+
+    def test_spine_id_exceeds_mesh_offsets(self, tmp_path):
+        """spine_id exceeding mesh offset count errors."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            # Add more root sections to skeleton (5 roots)
+            skel_path = (
+                f"{GRP_SPINES}/{GRP_SKELETONS}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            skel_grp = h5[skel_path]
+            del skel_grp["structure"]
+            skel_grp.create_dataset(
+                "structure",
+                data=np.array(
+                    [
+                        [0, 2, -1],
+                        [2, 2, -1],
+                        [4, 2, -1],
+                        [5, 1, -1],
+                        [6, 1, -1],
+                    ],
+                    dtype=np.int32,
+                ),
+            )
+            # Set spine_id to [0, 1, 4] — 4 exceeds mesh
+            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
+            del grp["spine_id"]
+            grp.create_dataset(
+                "spine_id",
+                data=np.array([0, 1, 4], dtype=np.uint32),
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert not result.is_valid
+        assert any(
+            "spine_id=4" in e and "mesh" in e
+            for e in result.errors
+        )
+
+    def test_spine_morphology_missing_mesh_warning(
+        self, tmp_path
+    ):
+        """spine_morphology referencing missing mesh warns."""
+        filepath = tmp_path / "test.h5"
+        write_minimal_valid_file(filepath)
+        with h5py.File(filepath, "a") as h5:
+            mesh_path = (
+                f"{GRP_SPINES}/{GRP_MESHES}"
+                f"/{SPINE_MORPH_NAME}"
+            )
+            h5.move(
+                mesh_path,
+                f"{GRP_SPINES}/{GRP_MESHES}/other_name",
+            )
+        result = validate_morph_with_spines_file(
+            filepath, check_data_integrity=True
+        )
+        assert any(
+            "spine_morphology" in w and "meshes" in w
+            for w in result.warnings
+        )
+
+
+class TestValidationResult:
+    """Tests for the ValidationResult dataclass."""
+
+    def test_initial_state(self):
+        """New ValidationResult has correct defaults."""
+        r = ValidationResult()
+        assert r.is_valid is True
+        assert r.data_integrity_checked is False
+        assert r.errors == []
+        assert r.warnings == []
+        assert r.info == []
+
+    def test_add_error_marks_invalid(self):
+        """add_error sets is_valid to False."""
+        r = ValidationResult()
+        r.add_error("something went wrong")
+        assert not r.is_valid
+        assert "something went wrong" in r.errors
+
+    def test_add_warning_keeps_valid(self):
+        """add_warning does not change is_valid."""
+        r = ValidationResult()
+        r.add_warning("minor issue")
+        assert r.is_valid
+        assert "minor issue" in r.warnings
+
+    def test_merge(self):
+        """merge combines errors, warnings, and info."""
+        r1 = ValidationResult()
+        r1.add_info("info1")
+        r2 = ValidationResult()
+        r2.add_error("error1")
+        r2.add_warning("warn1")
+        r1.merge(r2)
+        assert not r1.is_valid
+        assert "error1" in r1.errors
+        assert "warn1" in r1.warnings
+        assert "info1" in r1.info
+
+    def test_str_structure_only(self):
+        """__str__ shows 'structure only' when no data check."""
+        r = ValidationResult()
+        assert "structure only" in str(r)
+
+    def test_str_with_data_integrity(self):
+        """__str__ shows 'data integrity' when checked."""
+        r = ValidationResult(data_integrity_checked=True)
+        assert "data integrity" in str(r)
+
+    def test_str_all_sections(self):
+        """__str__ includes info, warnings, and errors."""
+        r = ValidationResult()
+        r.add_info("loaded file")
+        r.add_warning("heads up")
+        r.add_error("broken")
+        output = str(r)
+        assert "Info (1)" in output
+        assert "loaded file" in output
+        assert "Warnings (1)" in output
+        assert "heads up" in output
+        assert "Errors (1)" in output
+        assert "broken" in output
+        assert "INVALID" in output

--- a/tests/unit/utils/test_morph_spine_validator.py
+++ b/tests/unit/utils/test_morph_spine_validator.py
@@ -2,6 +2,7 @@
 
 import h5py
 import numpy as np
+import pytest
 
 from morph_spines.core.h5_schema import (
     ATT_VERSION,
@@ -30,295 +31,242 @@ class TestFileLevelChecks:
     """Tests for basic file-level validation checks."""
 
     def test_file_not_found(self, tmp_path):
-        """Nonexistent file produces 'not found' error."""
-        path = tmp_path / "nonexistent.h5"
-        result = validate_morph_with_spines_file(path)
-        assert not result.is_valid
-        assert any("not found" in e for e in result.errors)
+        r = validate_morph_with_spines_file(tmp_path / "nonexistent.h5")
+        assert not r.is_valid
+        assert any("not found" in e for e in r.errors)
 
     def test_not_hdf5(self, tmp_path):
-        """Plain text file produces 'Cannot open' error."""
-        path = tmp_path / "bad.h5"
-        path.write_text("not an hdf5 file")
-        result = validate_morph_with_spines_file(path)
-        assert not result.is_valid
-        assert any("Cannot open" in e for e in result.errors)
+        p = tmp_path / "bad.h5"
+        p.write_text("not an hdf5 file")
+        r = validate_morph_with_spines_file(p)
+        assert not r.is_valid
+        assert any("Cannot open" in e for e in r.errors)
 
     def test_valid_file_structure_only(self, tmp_path):
-        """Valid file passes structural validation."""
-        filepath = tmp_path / "valid.h5"
-        write_minimal_valid_file(filepath)
-        result = validate_morph_with_spines_file(filepath)
-        assert result.is_valid
-        assert not result.data_integrity_checked
+        r = validate_morph_with_spines_file(write_minimal_valid_file(tmp_path / "test.h5"))
+        assert r.is_valid
+        assert not r.data_integrity_checked
 
     def test_valid_file_with_data_integrity(self, tmp_path):
-        """Valid file passes with data integrity checks enabled."""
-        filepath = tmp_path / "valid.h5"
-        write_minimal_valid_file(filepath)
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert result.is_valid
-        assert result.data_integrity_checked
+        r = validate_morph_with_spines_file(
+            write_minimal_valid_file(tmp_path / "test.h5"), check_data_integrity=True
+        )
+        assert r.is_valid
+        assert r.data_integrity_checked
 
     def test_path_is_directory(self, tmp_path):
-        """Validating a directory path reports error."""
-        result = validate_morph_with_spines_file(tmp_path)
-        assert not result.is_valid
-        assert any("not a file" in e for e in result.errors)
+        r = validate_morph_with_spines_file(tmp_path)
+        assert not r.is_valid
+        assert any("not a file" in e for e in r.errors)
 
     def test_unexpected_top_level_groups(self, tmp_path):
-        """Unexpected top-level groups produce warning."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             h5.create_group("unexpected_group")
-        result = validate_morph_with_spines_file(filepath)
-        assert result.is_valid
-        assert any("unexpected_group" in w for w in result.warnings)
+        r = validate_morph_with_spines_file(filepath)
+        assert r.is_valid
+        assert any("unexpected_group" in w for w in r.warnings)
+
+    @pytest.mark.parametrize(
+        "groups,keyword",
+        [
+            ([GRP_EDGES, GRP_SPINES], "/morphology"),
+            ([GRP_MORPH, GRP_SPINES], "/edges"),
+            ([GRP_MORPH, GRP_EDGES], "/spines"),
+        ],
+        ids=["missing-morphology", "missing-edges", "missing-spines"],
+    )
+    def test_missing_required_group(self, tmp_path, groups, keyword):
+        filepath = tmp_path / "test.h5"
+        with h5py.File(filepath, "w") as h5:
+            for g in groups:
+                h5.create_group(g)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
 
 
 class TestMorphologyGroup:
     """Tests for /morphology group validation."""
 
-    def test_missing_morphology_group(self, tmp_path):
-        """File without /morphology reports error."""
-        filepath = tmp_path / "no_morph.h5"
-        with h5py.File(filepath, "w") as h5:
-            h5.create_group(GRP_EDGES)
-            h5.create_group(GRP_SPINES)
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("/morphology" in e for e in result.errors)
-
-    def test_missing_points_dataset(self, tmp_path):
-        """Missing points dataset in morphology reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize("dataset", ["points", "structure"])
+    def test_missing_dataset(self, tmp_path, dataset):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            del h5[f"{GRP_MORPH}/{NEURON_NAME}/points"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("missing 'points'" in e for e in result.errors)
+            del h5[f"{GRP_MORPH}/{NEURON_NAME}/{dataset}"]
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any(f"missing '{dataset}'" in e for e in r.errors)
 
     def test_wrong_points_shape(self, tmp_path):
-        """Points with wrong shape (3,3) reports shape error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
             del grp["points"]
-            grp.create_dataset(
-                "points",
-                data=np.ones((3, 3), dtype=np.float32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape (N, 4)" in e for e in result.errors)
+            grp.create_dataset("points", data=np.ones((3, 3), dtype=np.float32))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("shape (N, 4)" in e for e in r.errors)
 
     def test_points_not_float32_warning(self, tmp_path):
-        """Points with float64 dtype produces warning."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
             del grp["points"]
-            grp.create_dataset(
-                "points",
-                data=np.ones((3, 4), dtype=np.float64),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert result.is_valid
-        assert any("float32" in w for w in result.warnings)
+            grp.create_dataset("points", data=np.ones((3, 4), dtype=np.float64))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert r.is_valid
+        assert any("float32" in w for w in r.warnings)
 
-    def test_points_with_nan(self, tmp_path):
-        """Points containing NaN values reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "bad_value,keyword",
+        [
+            (np.nan, "NaN"),
+            (np.inf, "Inf"),
+        ],
+        ids=["nan", "inf"],
+    )
+    def test_points_bad_values(self, tmp_path, bad_value, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
             del grp["points"]
             data = np.ones((3, 4), dtype=np.float32)
-            data[1, 2] = np.nan
+            data[1, 2] = bad_value
             grp.create_dataset("points", data=data)
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("NaN" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
+
+    @pytest.mark.parametrize(
+        "dataset,shape,dtype",
+        [
+            ("points", (0, 4), np.float32),
+            ("structure", (0, 3), np.int32),
+        ],
+        ids=["empty-points", "empty-structure"],
+    )
+    def test_empty_dataset(self, tmp_path, dataset, shape, dtype):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
+        with h5py.File(filepath, "a") as h5:
+            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
+            del grp[dataset]
+            grp.create_dataset(dataset, data=np.empty(shape, dtype=dtype))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("empty" in e for e in r.errors)
 
     def test_empty_morphology_group(self, tmp_path):
-        """Empty /morphology group reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_MORPH}/{NEURON_NAME}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("empty" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("empty" in e for e in r.errors)
 
     def test_structure_wrong_shape(self, tmp_path):
-        """Structure with shape (3,2) reports shape error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
             del grp["structure"]
-            grp.create_dataset(
-                "structure",
-                data=np.ones((3, 2), dtype=np.int32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape (M, 3)" in e for e in result.errors)
-
-    def test_points_with_inf(self, tmp_path):
-        """Points containing Inf values reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
-            del grp["points"]
-            data = np.ones((3, 4), dtype=np.float32)
-            data[0, 0] = np.inf
-            grp.create_dataset("points", data=data)
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("Inf" in e for e in result.errors)
-
-    def test_empty_points(self, tmp_path):
-        """Empty points dataset reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
-            del grp["points"]
-            grp.create_dataset(
-                "points",
-                data=np.empty((0, 4), dtype=np.float32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("empty" in e for e in result.errors)
-
-    def test_empty_structure(self, tmp_path):
-        """Empty structure dataset reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_MORPH}/{NEURON_NAME}"]
-            del grp["structure"]
-            grp.create_dataset(
-                "structure",
-                data=np.empty((0, 3), dtype=np.int32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("empty" in e for e in result.errors)
+            grp.create_dataset("structure", data=np.ones((3, 2), dtype=np.int32))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("shape (M, 3)" in e for e in r.errors)
 
     def test_morphology_entry_is_dataset_not_group(self, tmp_path):
-        """A dataset instead of group under /morphology errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_MORPH}/{NEURON_NAME}"]
             h5[GRP_MORPH].create_dataset(NEURON_NAME, data=np.zeros(3))
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("not a group" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("not a group" in e for e in r.errors)
 
 
 class TestEdgesGroup:
     """Tests for /edges group validation."""
 
-    def test_missing_edges_group(self, tmp_path):
-        """File without /edges reports error."""
-        filepath = tmp_path / "no_edges.h5"
-        with h5py.File(filepath, "w") as h5:
-            h5.create_group(GRP_MORPH)
-            h5.create_group(GRP_SPINES)
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("/edges" in e for e in result.errors)
-
     def test_missing_mandatory_column(self, tmp_path):
-        """Missing spine_length column reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_EDGES}/{NEURON_NAME}/spine_length"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("spine_length" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("spine_length" in e for e in r.errors)
 
     def test_unknown_column_warning(self, tmp_path):
-        """Unknown column dataset produces warning."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            grp.create_dataset("unknown_col", data=np.zeros(3))
-        result = validate_morph_with_spines_file(filepath)
-        assert result.is_valid
-        assert any("unknown_col" in w for w in result.warnings)
+            h5[f"{GRP_EDGES}/{NEURON_NAME}"].create_dataset("unknown_col", data=np.zeros(3))
+        r = validate_morph_with_spines_file(filepath)
+        assert r.is_valid
+        assert any("unknown_col" in w for w in r.warnings)
 
     def test_wrong_metadata_version(self, tmp_path):
-        """Wrong spine table version reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             meta = h5[f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"]
             meta.attrs[ATT_VERSION] = np.array([99, 0], dtype=np.uint32)
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("version" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("version" in e for e in r.errors)
 
-    def test_afferent_section_pos_out_of_range(self, tmp_path):
-        """Section pos values outside [0,1] report error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "col,data,keyword",
+        [
+            ("afferent_section_pos", np.array([0.5, 1.5, -0.1], dtype=np.float64), "outside"),
+            ("spine_length", np.array([1.0, 0.0, -0.5], dtype=np.float64), "<= 0"),
+            ("afferent_segment_offset", np.array([0.1, -0.5, 0.3], dtype=np.float64), "negative"),
+        ],
+        ids=["section-pos-range", "spine-length-zero", "offset-negative"],
+    )
+    def test_range_validation(self, tmp_path, col, data, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            del grp["afferent_section_pos"]
-            grp.create_dataset(
-                "afferent_section_pos",
-                data=np.array([0.5, 1.5, -0.1], dtype=np.float64),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("outside" in e for e in result.errors)
+            del grp[col]
+            grp.create_dataset(col, data=data)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
 
-    def test_spine_length_zero(self, tmp_path):
-        """Spine length with zero or negative values errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "col",
+        [
+            "spine_volume",
+            "spine_neck_diameter",
+        ],
+    )
+    def test_optional_positive_column_invalid(self, tmp_path, col):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            del grp["spine_length"]
-            grp.create_dataset(
-                "spine_length",
-                data=np.array([1.0, 0.0, -0.5], dtype=np.float64),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("<= 0" in e for e in result.errors)
+            grp.create_dataset(col, data=np.array([0.5, -0.1, 0.0], dtype=np.float64))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(col in e and "<= 0" in e for e in r.errors)
 
-    def test_afferent_segment_offset_negative(self, tmp_path):
-        """Negative segment offset values report error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "col,bad_val,keyword",
+        [
+            ("afferent_surface_x", np.nan, "NaN"),
+            ("afferent_surface_y", np.inf, "Inf"),
+        ],
+        ids=["nan-in-float", "inf-in-float"],
+    )
+    def test_bad_float_values(self, tmp_path, col, bad_val, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            del grp["afferent_segment_offset"]
-            grp.create_dataset(
-                "afferent_segment_offset",
-                data=np.array([0.1, -0.5, 0.3], dtype=np.float64),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("negative" in e for e in result.errors)
+            del grp[col]
+            grp.create_dataset(col, data=np.array([1.0, bad_val, 3.0]))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
 
     def test_spine_morphology_invalid_reference(self, tmp_path):
-        """spine_morphology referencing nonexistent group."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["spine_morphology"]
@@ -328,65 +276,30 @@ class TestEdgesGroup:
                 data=np.array(["nonexistent_group"] * 3, dtype=object),
                 dtype=dt,
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("nonexistent_group" in e or "not in" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("nonexistent_group" in e or "not in" in e for e in r.errors)
 
     def test_empty_edges_group(self, tmp_path):
-        """Empty /edges group reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("empty" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("empty" in e for e in r.errors)
 
     def test_inconsistent_dataset_lengths(self, tmp_path):
-        """Datasets with different lengths report error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["spine_length"]
-            grp.create_dataset(
-                "spine_length",
-                data=np.array([1.0, 2.0], dtype=np.float64),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("inconsistent lengths" in e for e in result.errors)
-
-    def test_nan_in_float_column(self, tmp_path):
-        """NaN in float column reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            del grp["afferent_surface_x"]
-            data = np.array([1.0, np.nan, 3.0], dtype=np.float64)
-            grp.create_dataset("afferent_surface_x", data=data)
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("NaN" in e for e in result.errors)
-
-    def test_inf_in_float_column(self, tmp_path):
-        """Inf in float column reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
-            del grp["afferent_surface_y"]
-            data = np.array([1.0, np.inf, 3.0], dtype=np.float64)
-            grp.create_dataset("afferent_surface_y", data=data)
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("Inf" in e for e in result.errors)
+            grp.create_dataset("spine_length", data=np.array([1.0, 2.0]))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("inconsistent lengths" in e for e in r.errors)
 
     def test_wrong_dtype_for_integer_column(self, tmp_path):
-        """String dtype for integer column reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["afferent_section_id"]
@@ -396,238 +309,167 @@ class TestEdgesGroup:
                 data=np.array(["a", "b", "c"], dtype=object),
                 dtype=dt,
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("integer" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("integer" in e for e in r.errors)
 
     def test_edges_entry_is_dataset_not_group(self, tmp_path):
-        """A dataset instead of group under /edges errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             h5[GRP_EDGES].create_dataset(NEURON_NAME, data=np.zeros(3))
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("not a group" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("not a group" in e for e in r.errors)
 
     def test_edges_metadata_missing_version_attr(self, tmp_path):
-        """Metadata group without version attribute errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             meta = h5[f"{GRP_EDGES}/{NEURON_NAME}/{GRP_METADATA}"]
             del meta.attrs[ATT_VERSION]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("version" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("version" in e for e in r.errors)
 
     def test_spine_type_invalid_values(self, tmp_path):
-        """Invalid spine_type values report error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             dt = h5py.string_dtype(encoding="utf-8")
             grp.create_dataset(
                 "spine_type",
-                data=np.array(
-                    ["thin", "invalid_type", "mushroom"],
-                    dtype=object,
-                ),
+                data=np.array(["thin", "invalid_type", "mushroom"], dtype=object),
                 dtype=dt,
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("invalid_type" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("invalid_type" in e for e in r.errors)
 
 
 class TestSpinesGroup:
     """Tests for /spines group validation."""
 
-    def test_missing_spines_group(self, tmp_path):
-        """File without /spines reports error."""
-        filepath = tmp_path / "no_spines.h5"
-        with h5py.File(filepath, "w") as h5:
-            h5.create_group(GRP_MORPH)
-            h5.create_group(GRP_EDGES)
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("/spines" in e for e in result.errors)
-
     def test_missing_skeletons_subgroup(self, tmp_path):
-        """Missing /spines/skeletons reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("skeletons" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("skeletons" in e for e in r.errors)
 
     def test_meshes_optional(self, tmp_path):
-        """Missing /spines/meshes is valid with info message."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"{GRP_SPINES}/{GRP_MESHES}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert result.is_valid
-        assert any("not present" in i for i in result.info)
+        r = validate_morph_with_spines_file(filepath)
+        assert r.is_valid
+        assert any("not present" in i for i in r.info)
 
     def test_skeleton_wrong_points_shape(self, tmp_path):
-        """Skeleton points with shape (5,3) reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            skel_path = f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
-            grp = h5[skel_path]
-            del grp["points"]
-            grp.create_dataset(
-                "points",
-                data=np.ones((5, 3), dtype=np.float32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape (N, 4)" in e for e in result.errors)
+            skel = h5[f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"]
+            del skel["points"]
+            skel.create_dataset("points", data=np.ones((5, 3), dtype=np.float32))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("shape (N, 4)" in e for e in r.errors)
 
     def test_mesh_missing_offsets(self, tmp_path):
-        """Missing offsets dataset in mesh reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
+        mesh = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            del h5[f"{mesh_path}/{GRP_OFFSETS}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("offsets" in e for e in result.errors)
+            del h5[f"{mesh}/{GRP_OFFSETS}"]
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("offsets" in e for e in r.errors)
 
-    def test_mesh_vertices_nan(self, tmp_path):
-        """NaN in mesh vertices reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "bad_val,keyword",
+        [
+            (np.nan, "NaN"),
+            (np.inf, "Inf"),
+        ],
+        ids=["vertices-nan", "vertices-inf"],
+    )
+    def test_mesh_vertices_bad_values(self, tmp_path, bad_val, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
             del grp[GRP_VERTICES]
             data = np.ones((9, 3), dtype=np.float32)
-            data[2, 1] = np.nan
+            data[2, 1] = bad_val
             grp.create_dataset(GRP_VERTICES, data=data, compression="gzip")
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("NaN" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
 
-    def test_mesh_vertices_wrong_shape(self, tmp_path):
-        """Mesh vertices with shape (9,2) reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "dataset,bad_shape,keyword",
+        [
+            (GRP_VERTICES, (9, 2), "shape (N, 3)"),
+            (GRP_TRIANGLES, (3, 4), "shape (M, 3)"),
+            (GRP_OFFSETS, (4, 4), "shape"),
+        ],
+        ids=["vertices-shape", "triangles-shape", "offsets-shape"],
+    )
+    def test_mesh_wrong_shape(self, tmp_path, dataset, bad_shape, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
+        dtype = np.float32 if dataset == GRP_VERTICES else np.int32
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
-            del grp[GRP_VERTICES]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
+            del grp[dataset]
             grp.create_dataset(
-                GRP_VERTICES,
-                data=np.ones((9, 2), dtype=np.float32),
+                dataset,
+                data=np.ones(bad_shape, dtype=dtype),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape (N, 3)" in e for e in result.errors)
-
-    def test_mesh_triangles_wrong_shape(self, tmp_path):
-        """Mesh triangles with shape (3,4) reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
-            del grp[GRP_TRIANGLES]
-            grp.create_dataset(
-                GRP_TRIANGLES,
-                data=np.ones((3, 4), dtype=np.int32),
-                compression="gzip",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape (M, 3)" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any(keyword in e for e in r.errors)
 
     def test_triangle_index_out_of_bounds(self, tmp_path):
-        """Triangle index exceeding local vertex count."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
             del grp[GRP_TRIANGLES]
-            # Each spine has 3 local vertices; index 5 is OOB
             grp.create_dataset(
                 GRP_TRIANGLES,
-                data=np.array(
-                    [[0, 1, 5], [0, 1, 2], [0, 1, 2]],
-                    dtype=np.int32,
-                ),
+                data=np.array([[0, 1, 5], [0, 1, 2], [0, 1, 2]], dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("local vertex count" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("local vertex count" in e for e in r.errors)
 
-    def test_offsets_wrong_shape(self, tmp_path):
-        """Offsets with shape (4,4) reports shape error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "offsets_data",
+        [
+            np.array([[0, 0], [3, 1], [6, 2], [3, 3]], dtype=np.int32),
+            np.array([[0, 0], [3, 2], [6, 1], [9, 3]], dtype=np.int32),
+        ],
+        ids=["vertex-offsets-backward", "triangle-offsets-backward"],
+    )
+    def test_offsets_non_decreasing(self, tmp_path, offsets_data):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
             del grp[GRP_OFFSETS]
-            grp.create_dataset(
-                GRP_OFFSETS,
-                data=np.ones((4, 4), dtype=np.int32),
-                compression="gzip",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("shape" in e for e in result.errors)
-
-    def test_offsets_non_decreasing(self, tmp_path):
-        """Offsets going backwards reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
-            del grp[GRP_OFFSETS]
-            # Non-decreasing violation: 6 -> 3
-            grp.create_dataset(
-                GRP_OFFSETS,
-                data=np.array(
-                    [[0, 0], [3, 1], [6, 2], [3, 3]],
-                    dtype=np.int32,
-                ),
-                compression="gzip",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("non-decreasing" in e for e in result.errors)
+            grp.create_dataset(GRP_OFFSETS, data=offsets_data, compression="gzip")
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("non-decreasing" in e for e in r.errors)
 
     def test_offsets_first_row_not_zero(self, tmp_path):
-        """Offsets with non-zero first row produces warning."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
             del grp[GRP_OFFSETS]
-            # First row not zero
             grp.create_dataset(
                 GRP_OFFSETS,
-                data=np.array(
-                    [[1, 1], [4, 2], [7, 3], [10, 4]],
-                    dtype=np.int32,
-                ),
+                data=np.array([[1, 1], [4, 2], [7, 3], [10, 4]], dtype=np.int32),
                 compression="gzip",
             )
-            # Also need extra vertices/triangles to match
             del grp[GRP_VERTICES]
             grp.create_dataset(
                 GRP_VERTICES,
@@ -640,183 +482,109 @@ class TestSpinesGroup:
                 data=np.array([[0, 1, 2]] * 4, dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert result.is_valid
-        assert any("first row" in w for w in result.warnings)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert r.is_valid
+        assert any("first row" in w for w in r.warnings)
 
-    def test_skeleton_entry_is_dataset_not_group(self, tmp_path):
-        """A dataset instead of group under skeletons errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "subgroup",
+        [
+            GRP_SKELETONS,
+            GRP_MESHES,
+        ],
+        ids=["skeleton-is-dataset", "mesh-is-dataset"],
+    )
+    def test_entry_is_dataset_not_group(self, tmp_path, subgroup):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            skel_parent = h5[f"{GRP_SPINES}/{GRP_SKELETONS}"]
-            del skel_parent[SPINE_MORPH_NAME]
-            skel_parent.create_dataset(SPINE_MORPH_NAME, data=np.zeros(3))
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("not a group" in e for e in result.errors)
-
-    def test_mesh_entry_is_dataset_not_group(self, tmp_path):
-        """A dataset instead of group under meshes errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            mesh_parent = h5[f"{GRP_SPINES}/{GRP_MESHES}"]
-            del mesh_parent[SPINE_MORPH_NAME]
-            mesh_parent.create_dataset(SPINE_MORPH_NAME, data=np.zeros(3))
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("not a group" in e for e in result.errors)
-
-    def test_vertices_with_inf(self, tmp_path):
-        """Mesh vertices with Inf reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
-            del grp[GRP_VERTICES]
-            data = np.ones((9, 3), dtype=np.float32)
-            data[0, 0] = np.inf
-            grp.create_dataset(GRP_VERTICES, data=data, compression="gzip")
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("Inf" in e for e in result.errors)
+            parent = h5[f"{GRP_SPINES}/{subgroup}"]
+            del parent[SPINE_MORPH_NAME]
+            parent.create_dataset(SPINE_MORPH_NAME, data=np.zeros(3))
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("not a group" in e for e in r.errors)
 
     def test_offsets_single_row(self, tmp_path):
-        """Offsets with only 1 row reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
+            grp = h5[f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"]
             del grp[GRP_OFFSETS]
             grp.create_dataset(
                 GRP_OFFSETS,
                 data=np.array([[0, 0]], dtype=np.int32),
                 compression="gzip",
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("at least 2 rows" in e for e in result.errors)
-
-    def test_triangle_offsets_non_decreasing(self, tmp_path):
-        """Triangle offsets going backwards reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            grp = h5[mesh_path]
-            del grp[GRP_OFFSETS]
-            # Triangle offsets (col 1) go backwards
-            grp.create_dataset(
-                GRP_OFFSETS,
-                data=np.array(
-                    [[0, 0], [3, 2], [6, 1], [9, 3]],
-                    dtype=np.int32,
-                ),
-                compression="gzip",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("non-decreasing" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("at least 2 rows" in e for e in r.errors)
 
 
 class TestSomaGroup:
     """Tests for /soma group validation."""
 
     def test_soma_optional(self, tmp_path):
-        """Missing /soma is valid with info message."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5["soma"]
-        result = validate_morph_with_spines_file(filepath)
-        assert result.is_valid
-        assert any("soma" in i and "not present" in i for i in result.info)
+        r = validate_morph_with_spines_file(filepath)
+        assert r.is_valid
+        assert any("soma" in i and "not present" in i for i in r.info)
 
     def test_soma_missing_vertices(self, tmp_path):
-        """Missing vertices in soma mesh reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             del h5[f"soma/{GRP_MESHES}/{NEURON_NAME}/{GRP_VERTICES}"]
-        result = validate_morph_with_spines_file(filepath)
-        assert not result.is_valid
-        assert any("vertices" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath)
+        assert not r.is_valid
+        assert any("vertices" in e for e in r.errors)
 
-    def test_soma_vertices_wrong_shape(self, tmp_path):
-        """Soma vertices with shape (4,2) reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+    @pytest.mark.parametrize(
+        "dataset,bad_shape,keyword",
+        [
+            (GRP_VERTICES, (4, 2), "shape (N, 3)"),
+            (GRP_TRIANGLES, (2, 4), "shape (M, 3)"),
+        ],
+        ids=["soma-vertices-shape", "soma-triangles-shape"],
+    )
+    def test_soma_mesh_wrong_shape(self, tmp_path, dataset, bad_shape, keyword):
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
+        dtype = np.float32 if dataset == GRP_VERTICES else np.int32
         with h5py.File(filepath, "a") as h5:
             soma_path = f"soma/{GRP_MESHES}/{NEURON_NAME}"
-            del h5[f"{soma_path}/{GRP_VERTICES}"]
-            h5[soma_path].create_dataset(
-                GRP_VERTICES,
-                data=np.ones((4, 2), dtype=np.float32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("soma" in e and "vertices" in e and "shape (N, 3)" in e for e in result.errors)
-
-    def test_soma_triangles_wrong_shape(self, tmp_path):
-        """Soma triangles with shape (2,4) reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
-        with h5py.File(filepath, "a") as h5:
-            soma_path = f"soma/{GRP_MESHES}/{NEURON_NAME}"
-            del h5[f"{soma_path}/{GRP_TRIANGLES}"]
-            h5[soma_path].create_dataset(
-                GRP_TRIANGLES,
-                data=np.ones((2, 4), dtype=np.int32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("soma" in e and "triangles" in e and "shape (M, 3)" in e for e in result.errors)
+            del h5[f"{soma_path}/{dataset}"]
+            h5[soma_path].create_dataset(dataset, data=np.ones(bad_shape, dtype=dtype))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("soma" in e and keyword in e for e in r.errors)
 
 
 class TestCrossGroupIntegrity:
     """Tests for cross-group referential integrity."""
 
     def test_edges_neuron_not_in_morphology(self, tmp_path):
-        """Edges neuron not in /morphology reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            h5.move(
-                f"{GRP_MORPH}/{NEURON_NAME}",
-                f"{GRP_MORPH}/other_neuron",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("not in /morphology" in e for e in result.errors)
+            h5.move(f"{GRP_MORPH}/{NEURON_NAME}", f"{GRP_MORPH}/other_neuron")
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("not in /morphology" in e for e in r.errors)
 
     def test_spine_id_exceeds_skeleton_root_sections(self, tmp_path):
-        """spine_id exceeding root sections reports error."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["spine_id"]
-            grp.create_dataset(
-                "spine_id",
-                data=np.array([0, 1, 99], dtype=np.uint32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("spine_id=99" in e and "skeleton" in e for e in result.errors)
+            grp.create_dataset("spine_id", data=np.array([0, 1, 99], dtype=np.uint32))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("spine_id=99" in e and "skeleton" in e for e in r.errors)
 
     def test_spine_id_exceeds_mesh_offsets(self, tmp_path):
-        """spine_id exceeding mesh offset count errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            # Add more root sections to skeleton (5 roots)
-            skel_path = f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"
-            skel_grp = h5[skel_path]
-            del skel_grp["structure"]
-            skel_grp.create_dataset(
+            skel = h5[f"{GRP_SPINES}/{GRP_SKELETONS}/{SPINE_MORPH_NAME}"]
+            del skel["structure"]
+            skel.create_dataset(
                 "structure",
                 data=np.array(
                     [
@@ -829,53 +597,39 @@ class TestCrossGroupIntegrity:
                     dtype=np.int32,
                 ),
             )
-            # Set spine_id to [0, 1, 4] — 4 exceeds mesh
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["spine_id"]
-            grp.create_dataset(
-                "spine_id",
-                data=np.array([0, 1, 4], dtype=np.uint32),
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("spine_id=4" in e and "mesh" in e for e in result.errors)
+            grp.create_dataset("spine_id", data=np.array([0, 1, 4], dtype=np.uint32))
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("spine_id=4" in e and "mesh" in e for e in r.errors)
 
     def test_spine_morphology_missing_mesh_warning(self, tmp_path):
-        """spine_morphology referencing missing mesh warns."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            mesh_path = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
-            h5.move(
-                mesh_path,
-                f"{GRP_SPINES}/{GRP_MESHES}/other_name",
-            )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert any("spine_morphology" in w and "meshes" in w for w in result.warnings)
+            src = f"{GRP_SPINES}/{GRP_MESHES}/{SPINE_MORPH_NAME}"
+            h5.move(src, f"{GRP_SPINES}/{GRP_MESHES}/other_name")
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert any("spine_morphology" in w and "meshes" in w for w in r.warnings)
 
     def test_afferent_section_id_exceeds_morphology(self, tmp_path):
-        """afferent_section_id exceeding section count errors."""
-        filepath = tmp_path / "test.h5"
-        write_minimal_valid_file(filepath)
+        filepath = write_minimal_valid_file(tmp_path / "test.h5")
         with h5py.File(filepath, "a") as h5:
-            # Morphology has 1 section (structure has 1 row)
-            # Set afferent_section_id to 5 which is out of bounds
             grp = h5[f"{GRP_EDGES}/{NEURON_NAME}"]
             del grp["afferent_section_id"]
             grp.create_dataset(
                 "afferent_section_id",
                 data=np.array([0, 0, 5], dtype=np.uint32),
             )
-        result = validate_morph_with_spines_file(filepath, check_data_integrity=True)
-        assert not result.is_valid
-        assert any("afferent_section_id" in e for e in result.errors)
+        r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
+        assert not r.is_valid
+        assert any("afferent_section_id" in e for e in r.errors)
 
 
 class TestValidationResult:
     """Tests for the ValidationResult dataclass."""
 
     def test_initial_state(self):
-        """New ValidationResult has correct defaults."""
         r = ValidationResult()
         assert r.is_valid is True
         assert r.data_integrity_checked is False
@@ -884,21 +638,18 @@ class TestValidationResult:
         assert r.info == []
 
     def test_add_error_marks_invalid(self):
-        """add_error sets is_valid to False."""
         r = ValidationResult()
         r.add_error("something went wrong")
         assert not r.is_valid
         assert "something went wrong" in r.errors
 
     def test_add_warning_keeps_valid(self):
-        """add_warning does not change is_valid."""
         r = ValidationResult()
         r.add_warning("minor issue")
         assert r.is_valid
         assert "minor issue" in r.warnings
 
     def test_merge(self):
-        """merge combines errors, warnings, and info."""
         r1 = ValidationResult()
         r1.add_info("info1")
         r2 = ValidationResult()
@@ -911,17 +662,14 @@ class TestValidationResult:
         assert "info1" in r1.info
 
     def test_str_structure_only(self):
-        """__str__ shows 'structure only' when no data check."""
         r = ValidationResult()
         assert "structure only" in str(r)
 
     def test_str_with_data_integrity(self):
-        """__str__ shows 'data integrity' when checked."""
         r = ValidationResult(data_integrity_checked=True)
         assert "data integrity" in str(r)
 
     def test_str_all_sections(self):
-        """__str__ includes info, warnings, and errors."""
         r = ValidationResult()
         r.add_info("loaded file")
         r.add_warning("heads up")

--- a/tests/unit/utils/test_morph_spine_validator.py
+++ b/tests/unit/utils/test_morph_spine_validator.py
@@ -215,9 +215,9 @@ class TestEdgesGroup:
     @pytest.mark.parametrize(
         "col,data,keyword",
         [
-            ("afferent_section_pos", np.array([0.5, 1.5, -0.1], dtype=np.float64), "outside"),
-            ("spine_length", np.array([1.0, 0.0, -0.5], dtype=np.float64), "<= 0"),
-            ("afferent_segment_offset", np.array([0.1, -0.5, 0.3], dtype=np.float64), "negative"),
+            ("afferent_section_pos", np.array([0.5, 1.5, -0.1], dtype=np.float64), "not in [0, 1]"),
+            ("spine_length", np.array([1.0, 0.0, -0.5], dtype=np.float64), "not > 0"),
+            ("afferent_segment_offset", np.array([0.1, -0.5, 0.3], dtype=np.float64), "not >= 0"),
         ],
         ids=["section-pos-range", "spine-length-zero", "offset-negative"],
     )
@@ -245,7 +245,7 @@ class TestEdgesGroup:
             grp.create_dataset(col, data=np.array([0.5, -0.1, 0.0], dtype=np.float64))
         r = validate_morph_with_spines_file(filepath, check_data_integrity=True)
         assert not r.is_valid
-        assert any(col in e and "<= 0" in e for e in r.errors)
+        assert any(col in e and "not > 0" in e for e in r.errors)
 
     @pytest.mark.parametrize(
         "col,bad_val,keyword",


### PR DESCRIPTION
Fixes #39 

# Description

Adds `validate_morph_with_spines_file()` as a public API function that checks whether an HDF5 file conforms to the morph-spines format specification.

By default, validates file structure (groups, datasets, metadata). With `check_data_integrity=True`, also checks shapes, dtypes, value ranges, and cross-group referential integrity.

Includes updated testing and documentation.


## Validation checks
Structure (always):
- Required top-level groups, subgroups, and datasets exist
- Metadata version is (1, 0) for spine tables
- All mandatory spine table columns present
- `spine_morphology` in spines table references valid /spines/skeletons groups
- `spine_morphology` in spines table references valid /spines/meshes groups (warning)
- Spines table neuron names (/edges subgroups) match /morphology entries


Data integrity (optional):
- Dataset shapes (points N×4, structure M×3, vertices N×3, triangles M×3)
- Morphology points dtype is float32
- No NaN/Inf in coordinates (morphology points, spine mesh vertices)
- Spine table column dtypes match spec (float, int, string)
- No NaN/Inf in float columns of spine table
- Consistent dataset lengths within each spine table
- Value ranges in spine table:
  - `afferent_section_pos` in [0, 1]
  - `spine_length` > 0
  - `afferent_segment_offset` >= 0
  - `afferent_segment_id` >= 0
  - `spine_type` values are valid SpineType enum values (if present)
  - `spine_volume` > 0 (if present)
  - `spine_neck_diameter` > 0 (if present)
  - `spine_id` within bounds of skeleton root sections and mesh offsets
  - `afferent_section_id` within bounds of morphology section count
- Per-spine triangle indices < local vertex count (via offsets)
- Soma mesh triangle indices < vertex count



